### PR TITLE
Fixed JSON not parsing DateTime correctly

### DIFF
--- a/JavascriptDateTimeConverter.cs
+++ b/JavascriptDateTimeConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,7 +16,7 @@ namespace SlackAPI
 
         public override object ReadJson(Newtonsoft.Json.JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
         {
-            double value = double.Parse(reader.Value.ToString());
+            double value = double.Parse(reader.Value.ToString(), CultureInfo.InvariantCulture);
             return new DateTime(1970, 1, 1).Add(TimeSpan.FromSeconds(value)).ToLocalTime();
         }
 


### PR DESCRIPTION
The `double.Parse()` method parses strings according to the current system's culture, so parsing varies between many different devices. Some cultures can lead to wrong parsing, such as disregard of the decimal point.
This can lead to connection problems, such as when JSON data for `LoginResponse` is being deserialized, the `DateTime` class throws an `OverflowException`, which gets swallowed by the HTTP request callbacks used to fetch the response data for some reason, causing the connection to appear to fail on some cultures.