### PR TITLE
SAML/SSO Support in JSON Deserialization

### DIFF
--- a/TeamPreferences.cs
+++ b/TeamPreferences.cs
@@ -21,7 +21,8 @@ namespace SlackAPI
 
         public enum AuthMode
         {
-            normal
+            normal,
+            saml
         }
     }
 }


### PR DESCRIPTION
This fixes an exception generated by the JSON deserializer when trying to connect to a team that uses SAML authentication. Including this in the enumeration allows it to deserialize without a problem.