### PR TITLE
Fix Connect action order causing null underlying socket

### DIFF
--- a/SlackSocketClient.cs
+++ b/SlackSocketClient.cs
@@ -32,8 +32,8 @@ namespace SlackAPI
 		public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
 		{
 			base.Connect((s) => {
-				onConnected(s);
 				ConnectSocket(onSocketConnected);
+				onConnected(s);
 			});
 		}
 


### PR DESCRIPTION
Fixes a subsequent issue found after the fixing of Issue #8 