### PR TITLE
Add attachment tags, task.settopic and change get to post

### DIFF
--- a/Attachment.cs
+++ b/Attachment.cs
@@ -6,16 +6,26 @@ using System.Threading.Tasks;
 
 namespace SlackAPI
 {
+    //See: https://api.slack.com/docs/attachments
     public class Attachment
     {
-        public string Pretext;
-        public string text;
         public string fallback;
         public string color;
+        public string pretext;
+        
+        public string author_name;
+        public string author_link;
+        public string author_icon;
+        
+        public string title;
+        public string title_link;
+        
+        public string text;
         public Field[] fields;
+        
         public string image_url;
         public string thumb_url;
-        ///I have absolutely no idea what goes on in here.
+
     }
 
     public class Field{

--- a/RPCMessages/ChannelSetTopicResponse.cs
+++ b/RPCMessages/ChannelSetTopicResponse.cs
@@ -1,0 +1,8 @@
+namespace SlackAPI
+{
+    [RequestPath("channels.setTopic")]
+    public class ChannelSetTopicResponse : Response
+    {
+        public string topic;
+    }
+}

--- a/RequestStateForTask.cs
+++ b/RequestStateForTask.cs
@@ -24,7 +24,7 @@ namespace SlackAPI
 
         internal Task<K> Execute()
         {
-            if (Post.Length == 0)
+            if (Post == null || Post.Length == 0)
             {
                 request.Method = "GET";
                 return this.ExecuteResult();
@@ -67,6 +67,7 @@ namespace SlackAPI
         private async Task<K> ExecutePost()
         {
             request.Method = "POST";
+            request.ContentType = "application/x-www-form-urlencoded";
             using (Stream requestStream = await request.GetRequestStreamAsync())
             {
                 if (Post.Length > 0)
@@ -77,7 +78,7 @@ namespace SlackAPI
                         foreach (Tuple<string, string> postEntry in Post)
                         {
                             if (!first)
-                                writer.Write(',');
+                                writer.Write('&');
 
                             await writer.WriteAsync(string.Format("{0}={1}", Uri.EscapeDataString(postEntry.Item1), Uri.EscapeDataString(postEntry.Item2)));
 

--- a/SlackAPI.csproj
+++ b/SlackAPI.csproj
@@ -74,6 +74,7 @@
     <Compile Include="RPCMessages\GroupInviteResponse.cs" />
     <Compile Include="RPCMessages\GroupCloseResponse.cs" />
     <Compile Include="RPCMessages\DirectMessageConversationListResponse.cs" />
+    <Compile Include="RPCMessages\ChannelSetTopicResponse.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="File.cs" />
     <Compile Include="RPCMessages\FileInfoResponse.cs" />

--- a/SlackTaskClient.cs
+++ b/SlackTaskClient.cs
@@ -569,5 +569,12 @@ namespace SlackAPI
                 throw new NotImplementedException("This operation has not been implemented.");
             }
         }
+
+        public Task<ChannelSetTopicResponse> ChannelSetTopicAsync(string channelId, string newTopic)
+        {
+            return APIRequestWithTokenAsync<ChannelSetTopicResponse>(
+                    new Tuple<string, string>("channel", channelId),
+                    new Tuple<string, string>("topic", newTopic));
+        }
     }
 }

--- a/SlackTaskClient.cs
+++ b/SlackTaskClient.cs
@@ -123,17 +123,14 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<K>(new Tuple<string, string>[] { });
         }
  
-        public Task<K> APIRequestWithTokenAsync<K>(params Tuple<string,string>[] getParameters)
+        public Task<K> APIRequestWithTokenAsync<K>(params Tuple<string,string>[] postParameters)
             where K : Response
         {
             Tuple<string, string>[] tokenArray = new Tuple<string, string>[]{
                 new Tuple<string,string>("token", APIToken)
             };
 
-            if (getParameters != null && getParameters.Length > 0)
-                tokenArray = tokenArray.Concat(getParameters).ToArray();
-
-            return APIRequestAsync<K>(tokenArray, new Tuple<string, string>[0]);
+            return APIRequestAsync<K>(tokenArray, postParameters);
         }
 
         [Obsolete("Please use the OAuth method for authenticating users")]


### PR DESCRIPTION
In the current implementation a message bigger than 4kb breaks as it tries to send all the information as get parameters.

- I changed it to use post (and fixed the post message building).
- Added Channel Set Topic to SlackTaskClient.
- Added missing attributes in Attachment.