### PR TITLE
Add optional username to SendMessage

### DIFF
--- a/SlackSocketClient.cs
+++ b/SlackSocketClient.cs
@@ -74,9 +74,11 @@ namespace SlackAPI
                 userName = MySelf.id;
             }
 
-            underlyingSocket.Send(
-                new Message() { channel = channelId, text = textData, user = userName, type = "message" },
-                new Action<MessageReceived>(received => onSent?.Invoke(received)));
+            if (onSent != null) {
+                underlyingSocket.Send( new Message() {channel = channelId, text = textData, user = userName, type = "message"}, onSent);
+            } else {
+                underlyingSocket.Send(new Message() { channel = channelId, text = textData, user = userName, type = "message" });
+            }
         }
 
         public void HandleHello(Hello hello)

--- a/SlackSocketClient.cs
+++ b/SlackSocketClient.cs
@@ -26,7 +26,7 @@ namespace SlackAPI
         public SlackSocketClient(string token)
             : base(token)
         {
-            
+
         }
 
 		public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
@@ -67,12 +67,16 @@ namespace SlackAPI
             underlyingSocket.Send(new Typing() { channel = channelId });
         }
 
-        public void SendMessage(Action<MessageReceived> onSent, string channelId, string textData)
+        public void SendMessage(Action<MessageReceived> onSent, string channelId, string textData, string userName = null)
         {
-			underlyingSocket.Send(new Message() { channel = channelId, text = textData, user = MySelf.id, type = "message" }, new Action<MessageReceived>((mr) => {
-				if(onSent != null)
-					onSent(mr);
-			}));
+            if (userName == null)
+            {
+                userName = MySelf.id;
+            }
+
+            underlyingSocket.Send(
+                new Message() { channel = channelId, text = textData, user = userName, type = "message" },
+                new Action<MessageReceived>(received => onSent?.Invoke(received)));
         }
 
         public void HandleHello(Hello hello)
@@ -209,7 +213,7 @@ namespace SlackAPI
 
         public void ChannelMarked(ChannelMarked m)
         {
-            
+
         }
 
 		public void CloseSocket()


### PR DESCRIPTION
Using this SendMessage method, bots can change the display name that shows up to indicate, for instance, where they got the information from. This change breaks nothing, because by default the name will still be `MySelf.id` but now you can set it properly if you need to.