### PR TITLE
Improved chat.postMessage, implemented chat.update

### DIFF
--- a/Attachment.cs
+++ b/Attachment.cs
@@ -1,26 +1,24 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SlackAPI
+﻿namespace SlackAPI
 {
     public class Attachment
     {
-        public string Pretext;
-        public string text;
         public string fallback;
         public string color;
+        public string pretext;
+        public string author_name;
+        public string author_link;
+        public string author_icon;
+        public string title;
+        public string title_link;
+        public string text;
         public Field[] fields;
         public string image_url;
         public string thumb_url;
-        ///I have absolutely no idea what goes on in here.
     }
 
     public class Field{
         public string title;
         public string value;
-        public string @short;
+        public bool @short;
     }
 }

--- a/IntegrationTest/Helpers/InSync.cs
+++ b/IntegrationTest/Helpers/InSync.cs
@@ -1,0 +1,33 @@
+namespace IntegrationTest.Helpers
+{
+    using System;
+    using System.Threading;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Polly;
+
+    public class InSync : IDisposable
+    {
+        private readonly EventWaitHandle wait;
+
+        public InSync()
+        {
+            wait = new EventWaitHandle(false, EventResetMode.ManualReset);
+        }
+
+        public void Proceed()
+        {
+            wait.Set();
+        }
+
+        public void Dispose()
+        {
+            Policy
+                .Handle<AssertFailedException>()
+                .WaitAndRetry(15, x => TimeSpan.FromSeconds(0.2), (exception, span) => Console.WriteLine("Retrying in {0} seconds", span.TotalSeconds))
+                .Execute(() =>
+                {
+                    Assert.IsTrue(wait.WaitOne(), "Took too long to do the THING");
+                });
+        }
+    }
+}

--- a/IntegrationTest/Helpers/SlackMother.cs
+++ b/IntegrationTest/Helpers/SlackMother.cs
@@ -1,0 +1,29 @@
+﻿namespace IntegrationTest.Helpers
+{
+    using SlackAPI;
+
+    public class SlackMother
+    {
+        public static Attachment[] SomeAttachments => new[]
+        {
+            new Attachment()
+            {
+                fallback = "Required plain-text summary of the attachment.",
+                color = "#36a64f",
+                pretext = "Optional text that appears above the attachment block",
+                author_name = "Bobby Tables",
+                author_link = "http://flickr.com/bobby/",
+                author_icon = "http://flickr.com/icons/bobby.jpg",
+                title = "Slack API Documentation",
+                title_link = "https://api.slack.com/",
+                text = "Optional text that appears within the attachment",
+                fields = new[]
+                {
+                    new Field() { title = "Priority", value = "High", @short = false },
+                    new Field() { title = "Priority", value = "High", @short = true },
+                    new Field() { title = "Priority", value = "High", @short = true }
+                }
+            }
+        };
+    }
+}

--- a/IntegrationTest/IntegrationTest.csproj
+++ b/IntegrationTest/IntegrationTest.csproj
@@ -62,6 +62,10 @@
     <Compile Include="Configuration\SlackConfig.cs" />
     <Compile Include="Connect.cs" />
     <Compile Include="Helpers\ClientHelper.cs" />
+    <Compile Include="Helpers\InSync.cs" />
+    <Compile Include="Helpers\SlackMother.cs" />
+    <Compile Include="Update.cs" />
+    <Compile Include="PostMessage.cs" />
     <Compile Include="JoinDirectMessageChannel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/IntegrationTest/PostMessage.cs
+++ b/IntegrationTest/PostMessage.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using IntegrationTest.Configuration;
+using IntegrationTest.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Polly;
+
+namespace IntegrationTest
+{
+    using SlackAPI;
+
+    [TestClass]
+    public class PostMessage
+    {
+        private readonly Config _config;
+
+        public PostMessage()
+        {
+            _config = Config.GetConfig();
+        }
+
+        [TestMethod]
+        public void SimpleMessageDelivery()
+        {
+            // given
+            var client = ClientHelper.GetClient(_config.Slack.UserAuthToken);
+            PostMessageResponse actual = null;
+
+            // when
+            using (var sync = new InSync())
+            {
+                client.PostMessage(
+                    response =>
+                    {
+                        actual = response;
+                        sync.Proceed();
+                    },
+                    _config.Slack.TestChannel,
+                    "Hi there!");
+            }
+
+            // then
+            Assert.IsTrue(actual.ok, "Error while posting message to channel. ");
+            Assert.AreEqual(actual.message.text, "Hi there!");
+            Assert.AreEqual(actual.message.type, "message");
+        }
+
+        [TestMethod]
+        public void Attachments()
+        {
+            // given
+            var client = ClientHelper.GetClient(_config.Slack.UserAuthToken);
+            PostMessageResponse actual = null;
+
+            // when
+            using (var sync = new InSync())
+            {
+                client.PostMessage(
+                    response =>
+                    {
+                        actual = response;
+                        sync.Proceed();
+                    },
+                    _config.Slack.TestChannel,
+                    string.Empty,
+                    attachments: SlackMother.SomeAttachments);
+            }
+
+            // then
+            Assert.IsTrue(actual.ok, "Error while posting message to channel. ");
+        }
+    }
+}

--- a/IntegrationTest/Update.cs
+++ b/IntegrationTest/Update.cs
@@ -1,0 +1,69 @@
+﻿using System.Linq;
+using IntegrationTest.Configuration;
+using IntegrationTest.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace IntegrationTest
+{
+    using SlackAPI;
+
+    [TestClass]
+    public class Update 
+    {
+        private readonly Config _config;
+
+        public Update()
+        {
+            _config = Config.GetConfig();
+        }
+
+        [TestMethod]
+        public void SimpleUpdate()
+        {
+            // given
+            var client = ClientHelper.GetClient(_config.Slack.UserAuthToken);
+            var messageId = PostedMessage(client);
+            UpdateResponse actual = null;
+
+            // when
+            using (var sync = new InSync())
+            {
+                client.Update(
+                    response =>
+                    {
+                        actual = response;
+                        sync.Proceed();
+                    },
+                    messageId,
+                    _config.Slack.TestChannel,
+                    "[changed]",
+                    attachments: SlackMother.SomeAttachments,
+                    as_user: true);
+            }
+
+            // then
+            Assert.IsTrue(actual.ok, "Error while posting message to channel. ");
+            Assert.AreEqual(actual.message.text, "[changed]");
+            Assert.AreEqual(actual.message.type, "message");
+        }
+
+        private string PostedMessage(SlackSocketClient client)
+        {
+            string messageId = null;
+            using (var sync = new InSync())
+            {
+                client.PostMessage(
+                    response =>
+                    {
+                        messageId = response.ts;
+                        Assert.IsTrue(response.ok, "Error while posting message to channel. ");
+                        sync.Proceed();
+                    },
+                    _config.Slack.TestChannel,
+                    "Hi there!",
+                    as_user: true);
+            }
+            return messageId;
+        }
+    }
+}

--- a/RPCMessages/PostMessageResponse.cs
+++ b/RPCMessages/PostMessageResponse.cs
@@ -1,14 +1,21 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace SlackAPI
+﻿namespace SlackAPI
 {
     [RequestPath("chat.postMessage")]
     public class PostMessageResponse : Response
     {
+        public string ts;
+        public string channel;
+        public Message message;
 
+        public class Message
+        {
+            public string text;
+            public string user;
+            public string username;
+            public string type;
+            public string subtype;
+            public string ts;
+        }
     }
+
 }

--- a/RPCMessages/UpdateResponse.cs
+++ b/RPCMessages/UpdateResponse.cs
@@ -1,0 +1,18 @@
+﻿namespace SlackAPI
+{
+    [RequestPath("chat.update")]
+    public class UpdateResponse : Response
+    {
+        public string channel;
+        public string ts;
+        public string text;
+        public Message message;
+
+        public class Message
+        {
+            public string type;
+            public string user;
+            public string text;
+        }
+    }
+}

--- a/SlackAPI.csproj
+++ b/SlackAPI.csproj
@@ -80,6 +80,7 @@
     <Compile Include="RPCMessages\FileListResponse.cs" />
     <Compile Include="RPCMessages\FileUploadResponse.cs" />
     <Compile Include="RPCMessages\JoinDirectMessageChannelResponse.cs" />
+    <Compile Include="RPCMessages\UpdateResponse.cs" />
     <Compile Include="RPCMessages\UserCountsResponse.cs" />
     <Compile Include="RPCMessages\GroupListResponse.cs" />
     <Compile Include="RPCMessages\GroupMessageHistory.cs" />

--- a/SlackClient.cs
+++ b/SlackClient.cs
@@ -515,6 +515,40 @@ namespace SlackAPI
             APIRequestWithToken(callback, new Tuple<string, string>("agent", agent));
         }
 
+        public void Update(
+            Action<UpdateResponse> callback,
+            string ts,
+            string channelId,
+            string text,
+            string botName = null,
+            string parse = null,
+            bool linkNames = false,
+            Attachment[] attachments = null,
+            bool as_user = false)
+        {
+            List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
+
+            parameters.Add(new Tuple<string, string>("ts", ts));
+            parameters.Add(new Tuple<string, string>("channel", channelId));
+            parameters.Add(new Tuple<string, string>("text", text));
+
+            if (!string.IsNullOrEmpty(botName))
+                parameters.Add(new Tuple<string, string>("username", botName));
+
+            if (!string.IsNullOrEmpty(parse))
+                parameters.Add(new Tuple<string, string>("parse", parse));
+
+            if (linkNames)
+                parameters.Add(new Tuple<string, string>("link_names", "1"));
+
+            if (attachments != null && attachments.Length > 0)
+                parameters.Add(new Tuple<string, string>("attachments", JsonConvert.SerializeObject(attachments)));
+
+            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
+
         public void JoinDirectMessageChannel(Action<JoinDirectMessageChannelResponse> callback, string user)
         {
             var param = new Tuple<string, string>("user", user);


### PR DESCRIPTION
1. Attachments extended with all supported field, also fixed Prefix capitalization
2. PostMessage response extended with additional details being provided by Slack API
3. Implemented API call for chat.update
4. Implemented integration tests for both postMessage and update calls.
5. Refactored sync handling via manual reset event for greater test readability.