### PR TITLE
Raw field added in SlackSocketMessage

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
 
 namespace SlackAPI
 {
     public static class Extensions
     {
+        private static readonly JsonConverter[] Converters = { new JavascriptDateTimeConverter() };
+
         /// <summary>
         /// Converts to a propert JavaScript timestamp interpretted by Slack.  Also handles converting to UTC.
         /// </summary>
@@ -24,6 +24,26 @@ namespace SlackAPI
             }
             else
                 return that.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString();
+        }
+
+        public static K Deserialize<K>(this string data)
+            where K : class
+        {
+            return JsonConvert.DeserializeObject<K>(data, CreateSettings(data));
+        }
+
+        public static object Deserialize(this string data, Type type)
+        {
+            return JsonConvert.DeserializeObject(data, type, CreateSettings(data));
+        }
+
+        private static JsonSerializerSettings CreateSettings(object contextData)
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.Context = new StreamingContext(StreamingContextStates.Other, contextData);
+            settings.Converters = Converters;
+
+            return settings;
         }
     }
 }

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,13 +1,13 @@
 ﻿using System;
-using System.Runtime.Serialization;
-using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace SlackAPI
 {
     public static class Extensions
     {
-        private static readonly JsonConverter[] Converters = { new JavascriptDateTimeConverter() };
-
         /// <summary>
         /// Converts to a propert JavaScript timestamp interpretted by Slack.  Also handles converting to UTC.
         /// </summary>
@@ -24,26 +24,6 @@ namespace SlackAPI
             }
             else
                 return that.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString();
-        }
-
-        public static K Deserialize<K>(this string data)
-            where K : class
-        {
-            return JsonConvert.DeserializeObject<K>(data, CreateSettings(data));
-        }
-
-        public static object Deserialize(this string data, Type type)
-        {
-            return JsonConvert.DeserializeObject(data, type, CreateSettings(data));
-        }
-
-        private static JsonSerializerSettings CreateSettings(object contextData)
-        {
-            JsonSerializerSettings settings = new JsonSerializerSettings();
-            settings.Context = new StreamingContext(StreamingContextStates.Other, contextData);
-            settings.Converters = Converters;
-
-            return settings;
         }
     }
 }

--- a/Request.cs
+++ b/Request.cs
@@ -84,7 +84,7 @@ namespace SlackAPI
             using (StreamReader reader = new StreamReader(responseReading))
             {
                 string responseData = reader.ReadToEnd();
-                responseObj = JsonConvert.DeserializeObject<K>(responseData, new JavascriptDateTimeConverter());
+                responseObj = responseData.Deserialize<K>();
             }
 
             if(callback != null)

--- a/Request.cs
+++ b/Request.cs
@@ -84,7 +84,7 @@ namespace SlackAPI
             using (StreamReader reader = new StreamReader(responseReading))
             {
                 string responseData = reader.ReadToEnd();
-                responseObj = responseData.Deserialize<K>();
+                responseObj = JsonConvert.DeserializeObject<K>(responseData, new JavascriptDateTimeConverter());
             }
 
             if(callback != null)

--- a/RequestStateForTask.cs
+++ b/RequestStateForTask.cs
@@ -57,7 +57,7 @@ namespace SlackAPI
                 using (StreamReader reader = new StreamReader(responseReading))
                 {
                     string responseData = reader.ReadToEnd();
-                    responseObj = JsonConvert.DeserializeObject<K>(responseData, new JavascriptDateTimeConverter());
+                    responseObj = responseData.Deserialize<K>();
                 }
             }
 

--- a/RequestStateForTask.cs
+++ b/RequestStateForTask.cs
@@ -57,7 +57,7 @@ namespace SlackAPI
                 using (StreamReader reader = new StreamReader(responseReading))
                 {
                     string responseData = reader.ReadToEnd();
-                    responseObj = responseData.Deserialize<K>();
+                    responseObj = JsonConvert.DeserializeObject<K>(responseData, new JavascriptDateTimeConverter());
                 }
             }
 

--- a/SlackAPI.sln
+++ b/SlackAPI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackAPI", "SlackAPI.csproj", "{0C0A58A8-174E-4A4C-907B-C3569144D15D}"
 EndProject
@@ -26,13 +26,9 @@ Global
 		{0C0A58A8-174E-4A4C-907B-C3569144D15D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C0A58A8-174E-4A4C-907B-C3569144D15D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SlackAPI.sln
+++ b/SlackAPI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SlackAPI", "SlackAPI.csproj", "{0C0A58A8-174E-4A4C-907B-C3569144D15D}"
 EndProject
@@ -26,9 +26,13 @@ Global
 		{0C0A58A8-174E-4A4C-907B-C3569144D15D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C0A58A8-174E-4A4C-907B-C3569144D15D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C254F6FF-81D4-46DF-AA21-3D1A6456253B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19140E48-E1A9-421D-86DB-5AF18EECFEF2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SlackClient.cs
+++ b/SlackClient.cs
@@ -665,7 +665,7 @@ namespace SlackAPI
                 form.Add(new ByteArrayContent(fileData), "file", fileName);
                 HttpResponseMessage response = client.PostAsync(string.Format("{0}?{1}", target, string.Join("&", parameters.ToArray())), form).Result;
                 string result = response.Content.ReadAsStringAsync().Result;
-                callback(result.Deserialize<FileUploadResponse>());
+                callback(JsonConvert.DeserializeObject<FileUploadResponse>(result, new JavascriptDateTimeConverter()));
             }
         }
 

--- a/SlackClient.cs
+++ b/SlackClient.cs
@@ -665,7 +665,7 @@ namespace SlackAPI
                 form.Add(new ByteArrayContent(fileData), "file", fileName);
                 HttpResponseMessage response = client.PostAsync(string.Format("{0}?{1}", target, string.Join("&", parameters.ToArray())), form).Result;
                 string result = response.Content.ReadAsStringAsync().Result;
-                callback(JsonConvert.DeserializeObject<FileUploadResponse>(result, new JavascriptDateTimeConverter()));
+                callback(result.Deserialize<FileUploadResponse>());
             }
         }
 

--- a/SlackSocket.cs
+++ b/SlackSocket.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Runtime.Serialization;
 
 namespace SlackAPI
 {
@@ -112,7 +113,7 @@ namespace SlackAPI
             message.id = sendingId;
             callbacks.Add(sendingId, (c) =>
             {
-                K obj = JsonConvert.DeserializeObject<K>(c, new JavascriptDateTimeConverter());
+                K obj = c.Deserialize<K>();
                 callback(obj);
             });
             Send(message);
@@ -211,7 +212,7 @@ namespace SlackAPI
                         SlackSocketMessage message = null;
                         try
                         {
-                            message = JsonConvert.DeserializeObject<SlackSocketMessage>(data, new JavascriptDateTimeConverter());
+                            message = data.Deserialize<SlackSocketMessage>();
                         }
                         catch (JsonSerializationException jsonExcep)
                         {
@@ -245,13 +246,12 @@ namespace SlackAPI
                     object o = null;
                     if (routing.ContainsKey(message.type) &&
                         routing[message.type].ContainsKey(message.subtype ?? "null"))
-                        o = JsonConvert.DeserializeObject(data, routing[message.type][message.subtype ?? "null"],
-                            new JavascriptDateTimeConverter());
+                        o = data.Deserialize(routing[message.type][message.subtype ?? "null"]);
                     else
                     {
                         //I believe this method is slower than the former. If I'm wrong we can just use this instead. :D
                         Type t = routes[message.type][message.subtype ?? "null"].Method.GetParameters()[0].ParameterType;
-                        o = JsonConvert.DeserializeObject(data, t, new JavascriptDateTimeConverter());
+                        o = data.Deserialize(t);
                     }
                     routes[message.type][message.subtype ?? "null"].DynamicInvoke(o);
                 }
@@ -317,6 +317,13 @@ namespace SlackAPI
         public string subtype;
         public bool ok = true;
         public Error error;
+        public string raw;
+
+        [OnDeserialized]
+        public void OnDeserialized(StreamingContext context)
+        {
+          this.raw = context.Context as string;
+        }
     }
 
     public class Error

--- a/SlackSocket.cs
+++ b/SlackSocket.cs
@@ -214,7 +214,7 @@ namespace SlackAPI
                         {
                             message = data.Deserialize<SlackSocketMessage>();
                         }
-                        catch (JsonSerializationException jsonExcep)
+                        catch (JsonException jsonExcep)
                         {
                             if (ErrorReceivingDesiralization != null)
                                 ErrorReceivingDesiralization(jsonExcep);


### PR DESCRIPTION
- Raw field added in SlackSocketMessage.
- Deserialize/Deserialize<K> extension methods added to centralized deserialization options

This new raw field is useful to get full message json data for debugging purpose or to retrieve additional data (for example to retrieve attachments data in Message even if attachments deserialization is not yet implemented on SlackAPI side) 