### PR TITLE
Catch more general Json exception

### DIFF
--- a/SlackSocket.cs
+++ b/SlackSocket.cs
@@ -213,7 +213,7 @@ namespace SlackAPI
                         {
                             message = JsonConvert.DeserializeObject<SlackSocketMessage>(data, new JavascriptDateTimeConverter());
                         }
-                        catch (JsonSerializationException jsonExcep)
+                        catch (JsonException jsonExcep)
                         {
                             if (ErrorReceivingDesiralization != null)
                                 ErrorReceivingDesiralization(jsonExcep);


### PR DESCRIPTION
I noticed sometimes I can receive a GUID for reply_to instead a int. In this case, the code raises a JsonReaderException and this exception is not properly catched

Fault message example:
```
{
  "reply_to":"F17CFFB0-F9A2-48F0-A91E-0545D758E8FC",
  "type":"message",
  "channel":"C03NT48S9",
  "user":"U03MSJ74C",
  "text":"My text",
  "ts":"1466079251.000320"
}
```