### PR TITLE
Add Appveyor config

### DIFF
--- a/IntegrationTest/IntegrationTest.csproj
+++ b/IntegrationTest/IntegrationTest.csproj
@@ -76,9 +76,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Configuration\config.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="Configuration\config.default.json" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+version: 1.0.{build}
+
+build:
+  project: SlackAPI.sln
+  verbosity: minimal
+
+before_build:
+  - nuget restore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,3 +6,4 @@ build:
 
 before_build:
   - nuget restore
+  - copy .\IntegrationTest\Configuration\config.default.json .\IntegrationTest\Configuration\config.json


### PR DESCRIPTION
This fixes #63 as well as moving configuration into the repository itself.

Integration tests are still failing, but only because config.json is garbage values when Appveyor runs the tests. Next steps would probably be to make integration tests actually pass in Appveyor by injecting better values.
