### PR TITLE
G17 to F6 and removed trimming of trailing zeroes

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -18,10 +18,7 @@ namespace SlackAPI
         {
             if (toUTC)
             {
-                string result = ((that.ToUniversalTime().Ticks - 621355968000000000m) / 10000000m).ToString("G17");
-                if (result.Contains("."))
-                    result = result.TrimEnd('0');
-                return result;
+                return ((that.ToUniversalTime().Ticks - 621355968000000000m) / 10000000m).ToString("F6");
             }
             else
                 return that.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString();


### PR DESCRIPTION
(follow-up for #74 )

Changed .ToString("G17") to .ToString("F6") . Works the same as "0.000000" as far as I've tested.

Removed trimming of trailing zeros as we/Slack (now) want six decimal places in timestamp, even if the sixth digit is a zero.