### PR TITLE
Resolved Exception when Bot leaves Slack group

### DIFF
--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -171,7 +171,7 @@ namespace SlackAPI
 
         public void HandleGroupLeft(GroupLeft left)
         {
-            GroupLookup.Remove(left.channel.id);
+            GroupLookup.Remove(left.channel);
         }
 
         public void HandleGroupOpen(GroupOpen open)

--- a/SlackAPI/WebSocketMessages/GroupLeft.cs
+++ b/SlackAPI/WebSocketMessages/GroupLeft.cs
@@ -3,7 +3,7 @@
     [SlackSocketRouting("group_left")]
     public class GroupLeft : SlackSocketMessage
     {
-        public Channel channel;
+        public string channel;
     }
 }
 


### PR DESCRIPTION
Fixes #96 

**Files changed are:**

**1. SlackSocketClient.cs** - Fetched channelId
**2. GroupLeft.cs** - Updated the type from Channel to string.