### PR TITLE
Fix post message with new workspace token

### DIFF
--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -598,7 +598,7 @@ namespace SlackAPI
             bool unfurl_links = false,
             string icon_url = null,
             string icon_emoji = null,
-            bool as_user = false,
+            bool? as_user = null,
 	    string thread_ts = null)
         {
             List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
@@ -632,7 +632,8 @@ namespace SlackAPI
             if (!string.IsNullOrEmpty(icon_emoji))
                 parameters.Add(new Tuple<string, string>("icon_emoji", icon_emoji));
 
-            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+            if (as_user.HasValue)
+                parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
 		
             if (!string.IsNullOrEmpty(thread_ts))
                 parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));


### PR DESCRIPTION
With the new [workspace tokens](https://api.slack.com/docs/token-types#workspace), you shouldn't send `as_user` parameter, otherwise, you get `as_user_not_supported` error.