### PR TITLE
netcore2.0, bot_message return values, ephemeral messaging

### DIFF
--- a/SlackAPI.Tests/SlackAPI.Tests.NetCore.csproj
+++ b/SlackAPI.Tests/SlackAPI.Tests.NetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.0;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>SlackAPI.Tests</AssemblyName>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="1.1.0" />

--- a/SlackAPI.Tests/Users.cs
+++ b/SlackAPI.Tests/Users.cs
@@ -31,7 +31,8 @@ namespace SlackAPI.Tests
             Assert.True(actual.ok, "Error while fetching user list.");
             Assert.True(actual.members.Any());
 
-            var someMember = actual.members.First();
+            // apparently deleted users do indeed have null values, so if the first user returned is deleted then there are failures.
+            var someMember = actual.members.Where(x => !x.deleted).First();
             Assert.NotNull(someMember.id);
             Assert.NotNull(someMember.color);
             Assert.NotNull(someMember.real_name);

--- a/SlackAPI/RPCMessages/PostEphemeralResponse.cs
+++ b/SlackAPI/RPCMessages/PostEphemeralResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackAPI.RPCMessages
+{
+    [RequestPath("chat.postEphemeral")]
+    public class PostEphemeralResponse : Response
+    {
+        public string message_ts;
+        public string channel;
+    }
+}

--- a/SlackAPI/SlackAPI.NetCore.csproj
+++ b/SlackAPI/SlackAPI.NetCore.csproj
@@ -7,7 +7,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Inumedia</Authors>
-    <TargetFrameworks>net45;netstandard1.6;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net45;netstandard1.6;netstandard1.3</TargetFrameworks>
     <AssemblyName>SlackAPI</AssemblyName>
     <PackageProjectUrl>https://github.com/Inumedia/SlackAPI</PackageProjectUrl>
     <PackageLicenseUrl>http://choosealicense.com/licenses/mit/</PackageLicenseUrl>
@@ -24,6 +24,10 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.1" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
@@ -45,5 +49,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG;NET45</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -640,6 +640,42 @@ namespace SlackAPI
             APIRequestWithToken(callback, parameters.ToArray());
         }
 
+        public void PostEphemeralMessage(
+            Action<PostEphemeralResponse> callback,
+            string channelId,
+            string text,
+            string targetuser,
+            string parse = null,
+            bool linkNames = false,
+            Attachment[] attachments = null,
+            bool as_user = false,
+	    string thread_ts = null)
+        {
+            List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
+
+            parameters.Add(new Tuple<string,string>("channel", channelId));
+            parameters.Add(new Tuple<string,string>("text", text));
+            parameters.Add(new Tuple<string,string>("user", targetuser));
+
+            if (!string.IsNullOrEmpty(parse))
+                parameters.Add(new Tuple<string, string>("parse", parse));
+
+            if (linkNames)
+                parameters.Add(new Tuple<string, string>("link_names", "1"));
+
+            if (attachments != null && attachments.Length > 0)
+                parameters.Add(new Tuple<string, string>("attachments",
+                    JsonConvert.SerializeObject(attachments, Formatting.None,
+                            new JsonSerializerSettings // Shouldn't include a not set property
+                            {
+                                NullValueHandling = NullValueHandling.Ignore
+                            })));
+
+            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
+
 
         public void AddReaction(
             Action<ReactionAddedResponse> callback,

--- a/SlackAPI/SlackSocket.cs
+++ b/SlackAPI/SlackSocket.cs
@@ -41,7 +41,10 @@ namespace SlackAPI
         static SlackSocket()
         {
             routing = new Dictionary<string, Dictionary<string, Type>>();
-#if NET45
+
+#if NETCOREAPP2_0
+             var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.GlobalAssemblyCache == false);
+#elif NET45
              var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.GlobalAssemblyCache == false);
 #elif NETSTANDARD1_6
              var assemblies = DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load);

--- a/SlackAPI/WebSocketMessages/NewMessage.cs
+++ b/SlackAPI/WebSocketMessages/NewMessage.cs
@@ -12,6 +12,9 @@ namespace SlackAPI.WebSocketMessages
         public string team;
         public DateTime ts;
         public DateTime thread_ts;
+        public string username;
+        public string bot_id;
+        public UserProfile icons;
 
         public NewMessage()
         {


### PR DESCRIPTION
This adds three things:
1. Adds .netcoreapp2.0 support so that a warning is no longer thrown when using with netcoreapp2.0 projects
2. Adds username, bot_id, and icons to the NewMessage class so that when a bot_message is consumed all variables are available from the slack response.
3. Adds Ephemeral Response capabilities

Minor change:
Filters the users during the unit test so that it doesn't include deleted users. Deleted users can have null values which can cause a false failure in the unit test.