### PR TITLE
Fixed merge conflict for PR #135 + fix for #136

### DIFF
--- a/SlackAPI.Tests/SlackAPI.Tests.csproj
+++ b/SlackAPI.Tests/SlackAPI.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <DebugType>Full</DebugType>    
+    <DebugType>Full</DebugType>
     <RootNamespace>SlackAPI.Tests</RootNamespace>
     <AssemblyName>SlackAPI.Tests</AssemblyName>
   </PropertyGroup>

--- a/SlackAPI.Tests/Users.cs
+++ b/SlackAPI.Tests/Users.cs
@@ -31,7 +31,8 @@ namespace SlackAPI.Tests
             Assert.True(actual.ok, "Error while fetching user list.");
             Assert.True(actual.members.Any());
 
-            var someMember = actual.members.First();
+            // apparently deleted users do indeed have null values, so if the first user returned is deleted then there are failures.
+            var someMember = actual.members.Where(x => !x.deleted).First();
             Assert.NotNull(someMember.id);
             Assert.NotNull(someMember.color);
             Assert.NotNull(someMember.real_name);

--- a/SlackAPI/RPCMessages/PostEphemeralResponse.cs
+++ b/SlackAPI/RPCMessages/PostEphemeralResponse.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackAPI.RPCMessages
+{
+    [RequestPath("chat.postEphemeral")]
+    public class PostEphemeralResponse : Response
+    {
+        public string message_ts;
+        public string channel;
+    }
+}

--- a/SlackAPI/SlackAPI.csproj
+++ b/SlackAPI/SlackAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Configuration">
-    <TargetFrameworks>net45;netstandard1.3;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard1.6;netstandard2.0</TargetFrameworks>
     <DebugType>Full</DebugType>
     <RootNamespace>SlackAPI</RootNamespace>
     <AssemblyName>SlackAPI</AssemblyName>

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -639,6 +639,42 @@ namespace SlackAPI
             APIRequestWithToken(callback, parameters.ToArray());
         }
 
+        public void PostEphemeralMessage(
+            Action<PostEphemeralResponse> callback,
+            string channelId,
+            string text,
+            string targetuser,
+            string parse = null,
+            bool linkNames = false,
+            Attachment[] attachments = null,
+            bool as_user = false,
+	    string thread_ts = null)
+        {
+            List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
+
+            parameters.Add(new Tuple<string,string>("channel", channelId));
+            parameters.Add(new Tuple<string,string>("text", text));
+            parameters.Add(new Tuple<string,string>("user", targetuser));
+
+            if (!string.IsNullOrEmpty(parse))
+                parameters.Add(new Tuple<string, string>("parse", parse));
+
+            if (linkNames)
+                parameters.Add(new Tuple<string, string>("link_names", "1"));
+
+            if (attachments != null && attachments.Length > 0)
+                parameters.Add(new Tuple<string, string>("attachments",
+                    JsonConvert.SerializeObject(attachments, Formatting.None,
+                            new JsonSerializerSettings // Shouldn't include a not set property
+                            {
+                                NullValueHandling = NullValueHandling.Ignore
+                            })));
+
+            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
+
 
         public void AddReaction(
             Action<ReactionAddedResponse> callback,

--- a/SlackAPI/SlackSocket.cs
+++ b/SlackAPI/SlackSocket.cs
@@ -10,8 +10,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 
-#if NETSTANDARD1_6	
-using Microsoft.Extensions.DependencyModel;	
+#if NETSTANDARD1_6
+using Microsoft.Extensions.DependencyModel;
 #endif
 
 namespace SlackAPI
@@ -41,8 +41,9 @@ namespace SlackAPI
         static SlackSocket()
         {
             routing = new Dictionary<string, Dictionary<string, Type>>();
-#if NET45
-             var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.GlobalAssemblyCache == false);
+
+#if NET45 || NETSTANDARD2_0
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => x.GlobalAssemblyCache == false);
 #elif NETSTANDARD1_6
              var assemblies = DependencyContext.Default.GetDefaultAssemblyNames().Select(Assembly.Load);
 #elif NETSTANDARD1_3

--- a/SlackAPI/WebSocketMessages/NewMessage.cs
+++ b/SlackAPI/WebSocketMessages/NewMessage.cs
@@ -12,6 +12,9 @@ namespace SlackAPI.WebSocketMessages
         public string team;
         public DateTime ts;
         public DateTime thread_ts;
+        public string username;
+        public string bot_id;
+        public UserProfile icons;
 
         public NewMessage()
         {

--- a/SlackAPI/WebSocketMessages/NewMessage.cs
+++ b/SlackAPI/WebSocketMessages/NewMessage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace SlackAPI.WebSocketMessages
 {
@@ -15,6 +16,7 @@ namespace SlackAPI.WebSocketMessages
         public string username;
         public string bot_id;
         public UserProfile icons;
+        public List<Attachment> attachments;
 
         public NewMessage()
         {


### PR DESCRIPTION
Applied and fixed PR #135 
- Added support of netstandard 2.0 to avoid a warning message when using SlackAPI in netcore2.0
- Added bot_message return values
- Added ephemeral messaging

Fixed #136 
- Added attachments proeprty