### PR TITLE
WIP : Added full proxy support

### DIFF
--- a/SlackAPI.Tests/Configuration/IntegrationFixture.cs
+++ b/SlackAPI.Tests/Configuration/IntegrationFixture.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net;
 using System.Reflection;
+using System.Threading;
 using Newtonsoft.Json;
 using SlackAPI.Tests.Helpers;
 using Xunit;
@@ -16,15 +17,39 @@ namespace SlackAPI.Tests.Configuration
         public IntegrationFixture()
         {
             this.Config = this.GetConfig();
-            this.userClient = new Lazy<SlackSocketClient>(() => this.GetClient(this.Config.UserAuthToken));
-            this.botClient = new Lazy<SlackSocketClient>(() => this.GetClient(this.Config.BotAuthToken));
+            this.userClient = new Lazy<SlackSocketClient>(() => this.CreateClient(this.Config.UserAuthToken));
+            this.botClient = new Lazy<SlackSocketClient>(() => this.CreateClient(this.Config.BotAuthToken));
         }
 
         public SlackConfig Config { get; }
 
-        public SlackSocketClient UserClient => userClient.Value;
+        public SlackSocketClient UserClient
+        {
+            get
+            {
+                Assert.True(userClient.Value.IsReady);
+                return userClient.Value;
+            }
+        }
 
-        public SlackSocketClient BotClient => botClient.Value;
+        public SlackSocketClient BotClient
+        {
+            get
+            {
+                Assert.True(botClient.Value.IsReady);
+                return botClient.Value;
+            }
+        }
+
+        public SlackSocketClient CreateUserClient(IWebProxy proxySettings = null)
+        {
+            return this.CreateClient(this.Config.UserAuthToken, proxySettings);
+        }
+
+        public SlackSocketClient CreateBotClient(IWebProxy proxySettings = null)
+        {
+            return this.CreateClient(this.Config.BotAuthToken, proxySettings);
+        }
 
         public void Dispose()
         {
@@ -50,20 +75,29 @@ namespace SlackAPI.Tests.Configuration
             return JsonConvert.DeserializeAnonymousType(json, jsonObject).slack;
         }
 
-        private SlackSocketClient GetClient(string authToken)
+        private SlackSocketClient CreateClient(string authToken, IWebProxy proxySettings = null)
         {
             SlackSocketClient client;
 
+            LoginResponse loginResponse = null;
             using (var syncClient = new InSync($"{nameof(SlackClient.Connect)} - Connected callback"))
             using (var syncClientSocket = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected callback"))
             using (var syncClientSocketHello = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected hello callback"))
             {
-                client = new SlackSocketClient(authToken);
+                client = new SlackSocketClient(authToken, proxySettings);
                 client.OnHello += () => syncClientSocketHello.Proceed();
                 client.Connect(x =>
                 {
-                    Console.WriteLine("Connected");
+                    loginResponse = x;
+
+                    Console.WriteLine($"Connected {x.ok}");
                     syncClient.Proceed();
+                    if (!x.ok)
+                    {
+                        // If connect fails, socket connect callback is not called
+                        syncClientSocket.Proceed();
+                        syncClientSocketHello.Proceed();
+                    }
                 }, () =>
                 {
                     Console.WriteLine("Socket Connected");
@@ -71,7 +105,7 @@ namespace SlackAPI.Tests.Configuration
                 });
             }
 
-            Assert.True(client.IsConnected, "Doh, still isn't connected");
+            loginResponse.AssertOk();
 
             return client;
         }

--- a/SlackAPI.Tests/Configuration/IntegrationFixture.cs
+++ b/SlackAPI.Tests/Configuration/IntegrationFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using Newtonsoft.Json;
 using SlackAPI.Tests.Helpers;
@@ -55,8 +56,10 @@ namespace SlackAPI.Tests.Configuration
 
             using (var syncClient = new InSync($"{nameof(SlackClient.Connect)} - Connected callback"))
             using (var syncClientSocket = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected callback"))
+            using (var syncClientSocketHello = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected hello callback"))
             {
                 client = new SlackSocketClient(authToken);
+                client.OnHello += () => syncClientSocketHello.Proceed();
                 client.Connect(x =>
                 {
                     Console.WriteLine("Connected");

--- a/SlackAPI.Tests/Connect.cs
+++ b/SlackAPI.Tests/Connect.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 using SlackAPI.Tests.Configuration;
 using SlackAPI.Tests.Helpers;
 using SlackAPI.WebSocketMessages;
@@ -20,22 +21,32 @@ namespace SlackAPI.Tests
         [Fact]
         public void TestConnectAsUser()
         {
-            var client = this.fixture.UserClient;
+            var client = this.fixture.CreateUserClient();
             Assert.True(client.IsConnected, "Invalid, doesn't think it's connected.");
+            client.CloseSocket();
         }
 
         [Fact]
         public void TestConnectAsBot()
         {
-            var client = this.fixture.BotClient;
+            var client = this.fixture.CreateBotClient();
             Assert.True(client.IsConnected, "Invalid, doesn't think it's connected.");
+            client.CloseSocket();
+        }
+
+        [Fact]
+        public void TestConnectWithWrongProxySettings()
+        {
+            var proxySettings = new WebProxy { Address = new Uri("http://127.0.0.1:8080")};
+            Assert.Throws<InvalidOperationException>(() => this.fixture.CreateUserClient(proxySettings));
+            Assert.Throws<InvalidOperationException>(() => this.fixture.CreateBotClient(proxySettings));
         }
 
         [Fact]
         public void TestConnectPostAndDelete()
         {
             // given
-            SlackSocketClient client = this.fixture.UserClient;
+            SlackSocketClient client = this.fixture.CreateUserClient();
             string channel = this.fixture.Config.TestChannel;
 
             // when

--- a/SlackAPI.Tests/UserUIInteraction.cs
+++ b/SlackAPI.Tests/UserUIInteraction.cs
@@ -40,25 +40,26 @@ namespace SlackAPI.Tests
                 driver.FindElement(By.Id("password")).SendKeys(authPassword);
                 driver.FindElement(By.Id("signin_btn")).Click();
 
-                var uri = SlackClient.GetAuthorizeUri(clientId, SlackScope.Identify);
+                var slackClientHelpers = new SlackClientHelpers();
+                var uri = slackClientHelpers.GetAuthorizeUri(clientId, SlackScope.Identify);
                 driver.Navigate().GoToUrl(uri);
                 driver.FindElement(By.Id("oauth_authorizify")).Click();
 
                 var code = Regex.Match(driver.Url, "code=(?<code>[^&]+)&state").Groups["code"].Value;
 
-                var accessTokenResponse = GetAccessToken(clientId, clientSecret, redirectUrl, code);
+                var accessTokenResponse = GetAccessToken(slackClientHelpers, clientId, clientSecret, redirectUrl, code);
                 Assert.True(accessTokenResponse.ok);
                 Assert.Equal("identify", accessTokenResponse.scope);
             }
         }
 
-        private AccessTokenResponse GetAccessToken(string clientId, string clientSecret, string redirectUri, string authCode)
+        private AccessTokenResponse GetAccessToken(SlackClientHelpers slackClientHelpers, string clientId, string clientSecret, string redirectUri, string authCode)
         {
             AccessTokenResponse accessTokenResponse = null;
 
-            using (var sync = new InSync(nameof(SlackClient.GetAccessToken)))
+            using (var sync = new InSync(nameof(slackClientHelpers.GetAccessToken)))
             {
-                SlackClient.GetAccessToken(response =>
+                slackClientHelpers.GetAccessToken(response =>
                 {
                     accessTokenResponse = response;
                     sync.Proceed();

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -52,8 +52,9 @@ namespace SlackAPI
         {
             EmitLogin((loginDetails) =>
             {
-				if(loginDetails.ok)
-					Connected(loginDetails);
+                loginDetails.AssertOk();
+                Connected(loginDetails);
+
                 if (onConnected != null)
                     onConnected(loginDetails);
             });

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -52,8 +52,8 @@ namespace SlackAPI
         {
             EmitLogin((loginDetails) =>
             {
-                loginDetails.AssertOk();
-                Connected(loginDetails);
+                if (loginDetails.ok)
+                    Connected(loginDetails);
 
                 if (onConnected != null)
                     onConnected(loginDetails);

--- a/SlackAPI/SlackClientBase.cs
+++ b/SlackAPI/SlackClientBase.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+
+namespace SlackAPI
+{
+    public abstract class SlackClientBase
+    {
+        protected readonly IWebProxy proxySettings;
+        private readonly HttpClient httpClient;
+        protected const string APIBaseLocation = "https://slack.com/api/";
+
+        protected SlackClientBase()
+        {
+            this.httpClient = new HttpClient();
+        }
+
+        protected SlackClientBase(IWebProxy proxySettings)
+        {
+            this.proxySettings = proxySettings;
+            this.httpClient = new HttpClient(new HttpClientHandler { UseProxy = true, Proxy = proxySettings });
+        }
+
+        protected Uri GetSlackUri(string path, Tuple<string, string>[] getParameters)
+        {
+            string parameters = getParameters
+                .Where(x => x.Item2 != null)
+                .Select(new Func<Tuple<string, string>, string>(a =>
+                {
+                    try
+                    {
+                        return string.Format("{0}={1}", Uri.EscapeDataString(a.Item1), Uri.EscapeDataString(a.Item2));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new InvalidOperationException(string.Format("Failed when processing '{0}'.", a), ex);
+                    }
+                }))
+                .Aggregate((a, b) =>
+                {
+                    if (string.IsNullOrEmpty(a))
+                        return b;
+                    else
+                        return string.Format("{0}&{1}", a, b);
+                });
+
+            Uri requestUri = new Uri(string.Format("{0}?{1}", path, parameters));
+            return requestUri;
+        }
+
+        protected void APIRequest<K>(Action<K> callback, Tuple<string, string>[] getParameters, Tuple<string, string>[] postParameters)
+            where K : Response
+        {
+            RequestPath path = RequestPath.GetRequestPath<K>();
+            //TODO: Custom paths? Appropriate subdomain paths? Not sure.
+            //Maybe store custom path in the requestpath.path itself?
+
+            Uri requestUri = GetSlackUri(Path.Combine(APIBaseLocation, path.Path), getParameters);
+            HttpWebRequest request = CreateWebRequest(requestUri);
+
+            //This will handle all of the processing.
+            RequestState<K> state = new RequestState<K>(request, postParameters, callback);
+            state.Begin();
+        }
+
+        public Task<K> APIRequestAsync<K>(Tuple<string, string>[] getParameters, Tuple<string, string>[] postParameters)
+            where K : Response
+        {
+            RequestPath path = RequestPath.GetRequestPath<K>();
+            //TODO: Custom paths? Appropriate subdomain paths? Not sure.
+            //Maybe store custom path in the requestpath.path itself?
+
+            Uri requestUri = GetSlackUri(Path.Combine(APIBaseLocation, path.Path), getParameters);
+            HttpWebRequest request = CreateWebRequest(requestUri);
+
+            //This will handle all of the processing.
+            var state = new RequestStateForTask<K>(request, postParameters);
+            return state.Execute();
+        }
+
+        protected void APIGetRequest<K>(Action<K> callback, params Tuple<string, string>[] getParameters)
+            where K : Response
+        {
+            APIRequest<K>(callback, getParameters, new Tuple<string, string>[0]);
+        }
+
+        public Task<K> APIGetRequestAsync<K>(params Tuple<string, string>[] getParameters)
+            where K : Response
+        {
+            return APIRequestAsync<K>(getParameters, new Tuple<string, string>[0]);
+        }
+
+        protected HttpWebRequest CreateWebRequest(Uri requestUri)
+        {
+            var httpWebRequest = (HttpWebRequest)HttpWebRequest.Create(requestUri);
+            if (proxySettings != null)
+            {
+                httpWebRequest.Proxy = this.proxySettings;
+            }
+
+            return httpWebRequest;
+        }
+
+        protected HttpResponseMessage PostRequest(string requestUri, MultipartFormDataContent form)
+        {
+            return httpClient.PostAsync(requestUri, form).Result;
+        }
+
+        public void RegisterConverter(JsonConverter converter)
+        {
+            if (converter == null)
+            {
+                throw new ArgumentNullException("converter");
+            }
+
+            Extensions.Converters.Add(converter);
+        }
+    }
+}

--- a/SlackAPI/SlackClientHelpers.cs
+++ b/SlackAPI/SlackClientHelpers.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackAPI
+{
+    public class SlackClientHelpers : SlackClientBase
+    {
+        public SlackClientHelpers()
+        {
+        }
+
+        public SlackClientHelpers(IWebProxy proxySettings)
+            : base(proxySettings)
+        {
+        }
+
+        [Obsolete("Please use the OAuth method for authenticating users")]
+        public void StartAuth(Action<AuthStartResponse> callback, string email)
+        {
+            APIRequest(callback, new Tuple<string, string>[] { new Tuple<string, string>("email", email) }, new Tuple<string, string>[0]);
+        }
+
+        [Obsolete("Please use the OAuth method for authenticating users")]
+        public Task<AuthStartResponse> StartAuthAsync(string email)
+        {
+            return APIRequestAsync<AuthStartResponse>(new Tuple<string, string>[] { new Tuple<string, string>("email", email) }, new Tuple<string, string>[0]);
+        }
+
+        public void FindTeam(Action<FindTeamResponse> callback, string team)
+        {
+            //This seems to accept both 'team.slack.com' and just plain 'team'.
+            //Going to go with the latter.
+            Tuple<string, string> domainName = new Tuple<string, string>("domain", team);
+            APIRequest(callback, new Tuple<string, string>[] { domainName }, new Tuple<string, string>[0]);
+        }
+
+        public Task<FindTeamResponse> FindTeam(string team)
+        {
+            //This seems to accept both 'team.slack.com' and just plain 'team'.
+            //Going to go with the latter.
+            Tuple<string, string> domainName = new Tuple<string, string>("domain", team);
+            return APIRequestAsync<FindTeamResponse>(new Tuple<string, string>[] { domainName }, new Tuple<string, string>[0]);
+        }
+
+        public void AuthSignin(Action<AuthSigninResponse> callback, string userId, string teamId, string password)
+        {
+            APIRequest(callback, new Tuple<string, string>[] {
+                new Tuple<string,string>("user", userId),
+                new Tuple<string,string>("team", teamId),
+                new Tuple<string,string>("password", password)
+            }, new Tuple<string, string>[0]);
+        }
+
+        public Task<AuthSigninResponse> AuthSignin(string userId, string teamId, string password)
+        {
+            return APIRequestAsync<AuthSigninResponse>(new Tuple<string, string>[] {
+                new Tuple<string,string>("user", userId),
+                new Tuple<string,string>("team", teamId),
+                new Tuple<string,string>("password", password)
+            }, new Tuple<string, string>[0]);
+        }
+
+        public Uri GetAuthorizeUri(string clientId, SlackScope scopes, string redirectUri = null, string state = null, string team = null)
+        {
+            string theScopes = BuildScope(scopes);
+
+            return GetSlackUri("https://slack.com/oauth/authorize", new Tuple<string, string>[] { new Tuple<string, string>("client_id", clientId),
+                new Tuple<string, string>("redirect_uri", redirectUri),
+                new Tuple<string, string>("state", state),
+                new Tuple<string, string>("scope", theScopes),
+                new Tuple<string, string>("team", team)});
+        }
+
+        public void GetAccessToken(Action<AccessTokenResponse> callback, string clientId, string clientSecret, string redirectUri, string code)
+        {
+            APIRequest<AccessTokenResponse>(callback, new Tuple<string, string>[] { new Tuple<string, string>("client_id", clientId),
+                new Tuple<string, string>("client_secret", clientSecret), new Tuple<string, string>("code", code),
+                new Tuple<string, string>("redirect_uri", redirectUri) }, new Tuple<string, string>[] { });
+        }
+
+        private string BuildScope(SlackScope scope)
+        {
+            var builder = new StringBuilder();
+            if ((int)(scope & SlackScope.Identify) != 0)
+                builder.Append("identify");
+            if ((int)(scope & SlackScope.Read) != 0)
+            {
+                if (builder.Length > 0)
+                    builder.Append(",");
+                builder.Append("read");
+            }
+            if ((int)(scope & SlackScope.Post) != 0)
+            {
+                if (builder.Length > 0)
+                    builder.Append(",");
+                builder.Append("post");
+            }
+            if ((int)(scope & SlackScope.Client) != 0)
+            {
+                if (builder.Length > 0)
+                    builder.Append(",");
+                builder.Append("client");
+            }
+            if ((int)(scope & SlackScope.Admin) != 0)
+            {
+                if (builder.Length > 0)
+                    builder.Append(",");
+                builder.Append("admin");
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/SlackAPI/SlackSocket.cs
+++ b/SlackAPI/SlackSocket.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Net;
 
 #if NETSTANDARD1_6
 using Microsoft.Extensions.DependencyModel;
@@ -91,10 +92,15 @@ namespace SlackAPI
             }
         }
 
-		public SlackSocket(LoginResponse loginDetails, object routingTo, Action onConnected = null)
+		public SlackSocket(LoginResponse loginDetails, object routingTo, Action onConnected = null, IWebProxy proxySettings = null)
         {
             BuildRoutes(routingTo);
             socket = new ClientWebSocket();
+            if (proxySettings != null)
+            {
+                socket.Options.Proxy = proxySettings;
+            }
+
             callbacks = new Dictionary<int, Action<string>>();
             sendingQueue = new LockFreeQueue<string>();
             currentId = 1;

--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.WebSockets;
 using System;
-using System.Diagnostics;
-using System.Threading;
+using System.Net;
 using SlackAPI.WebSocketMessages;
 
 namespace SlackAPI
@@ -22,12 +21,16 @@ namespace SlackAPI
         public bool IsConnected { get { return underlyingSocket != null && underlyingSocket.Connected; } }
 
         public event Action OnHello;
-		internal LoginResponse loginDetails;
+        private LoginResponse loginDetails;
 
         public SlackSocketClient(string token)
             : base(token)
         {
+        }
 
+        public SlackSocketClient(string token, IWebProxy proxySettings)
+            : base(token, proxySettings)
+        {
         }
 
 		public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
@@ -45,7 +48,7 @@ namespace SlackAPI
 		}
 
 		public void ConnectSocket(Action onSocketConnected){
-			underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected);
+			underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected, this.proxySettings);
 		}
 
         public void ErrorReceiving<K>(Action<WebSocketException> callback)

--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -33,23 +33,25 @@ namespace SlackAPI
         {
         }
 
-		public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
-		{
-			base.Connect((s) => {
-				ConnectSocket(onSocketConnected);
-				onConnected(s);
-			});
-		}
+        public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
+        {
+            base.Connect((s) => {
+                if (s.ok)
+                    ConnectSocket(onSocketConnected);
+
+                onConnected(s);
+            });
+        }
 
         protected override void Connected(LoginResponse loginDetails)
-		{
-			this.loginDetails = loginDetails;
-			base.Connected(loginDetails);
-		}
+        {
+            this.loginDetails = loginDetails;
+            base.Connected(loginDetails);
+        }
 
-		public void ConnectSocket(Action onSocketConnected){
-			underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected, this.proxySettings);
-		}
+        public void ConnectSocket(Action onSocketConnected){
+            underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected, this.proxySettings);
+        }
 
         public void ErrorReceiving<K>(Action<WebSocketException> callback)
         {

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -6,28 +6,13 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace SlackAPI
 {
-    public class SlackTaskClient
+    public class SlackTaskClient : SlackClientBase
     {
-        readonly string APIToken;
-
-        const string APIBaseLocation = "https://slack.com/api/";
-        const int Timeout = 5000;
-
-        const char StartHighlight = '\uE001';
-        const char EndHightlight = '\uE001';
-
-        static List<Tuple<string, string>> replacers = new List<Tuple<string, string>>(){
-            new Tuple<string,string>("&", "&amp;"),
-            new Tuple<string,string>("<", "&lt;"),
-            new Tuple<string,string>(">", "&gt;")
-        };
-
-        //Dictionary<int, Action<ReceivingMessage>> socketCallbacks;
+        private readonly string APIToken;
 
         public Self MySelf;
         public User MyData;
@@ -45,21 +30,22 @@ namespace SlackAPI
         public Dictionary<string, Channel> GroupLookup;
         public Dictionary<string, DirectMessageConversation> DirectMessageLookup;
 
-        //public event Action<ReceivingMessage> OnUserTyping;
-        //public event Action<ReceivingMessage> OnMessageReceived;
-        //public event Action<ReceivingMessage> OnPresenceChanged;
-        //public event Action<ReceivingMessage> OnHello;
-
         public SlackTaskClient(string token)
         {
             APIToken = token;
         }
 
-		public virtual async Task<LoginResponse> ConnectAsync()
+        public SlackTaskClient(string token, IWebProxy proxySettings)
+            : base(proxySettings)
+        {
+            APIToken = token;
+        }
+
+        public virtual async Task<LoginResponse> ConnectAsync()
         {
             var loginDetails = await EmitLoginAsync();
-			if(loginDetails.ok)
-				Connected(loginDetails);
+            if(loginDetails.ok)
+                Connected(loginDetails);
 
             return loginDetails;
         }
@@ -95,27 +81,6 @@ namespace SlackAPI
             foreach (DirectMessageConversation im in DirectMessages) DirectMessageLookup.Add(im.id, im);
         }
 
-        public static Task<K> APIRequestAsync<K>(Tuple<string, string>[] getParameters, Tuple<string, string>[] postParameters)
-            where K : Response
-        {
-            RequestPath path = RequestPath.GetRequestPath<K>();
-            //TODO: Custom paths? Appropriate subdomain paths? Not sure.
-            //Maybe store custom path in the requestpath.path itself?
-
-            Uri requestUri = SlackClient.GetSlackUri(Path.Combine(APIBaseLocation, path.Path), getParameters);
-            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(requestUri);
-
-            //This will handle all of the processing.
-            var state = new RequestStateForTask<K>(request, postParameters);
-            return state.Execute();
-        }
-
-        public static Task<K> APIGetRequestAsync<K>(params Tuple<string, string>[] getParameters)
-            where K : Response
-        {
-            return APIRequestAsync<K>(getParameters, new Tuple<string, string>[0]);
-        }
-
         public Task<K> APIRequestWithTokenAsync<K>()
             where K : Response
         {
@@ -130,29 +95,6 @@ namespace SlackAPI
             };
 
             return APIRequestAsync<K>(tokenArray, postParameters);
-        }
-
-        [Obsolete("Please use the OAuth method for authenticating users")]
-        public static Task<AuthStartResponse> StartAuthAsync(string email)
-        {
-            return APIRequestAsync<AuthStartResponse>(new Tuple<string, string>[] { new Tuple<string, string>("email", email) }, new Tuple<string, string>[0]);
-        }
-
-        public static Task<FindTeamResponse> FindTeam(string team)
-        {
-            //This seems to accept both 'team.slack.com' and just plain 'team'.
-            //Going to go with the latter.
-            Tuple<string, string> domainName = new Tuple<string, string>("domain", team);
-            return APIRequestAsync<FindTeamResponse>(new Tuple<string, string>[] { domainName }, new Tuple<string, string>[0]);
-        }
-
-        public static Task<AuthSigninResponse> AuthSignin(string userId, string teamId, string password)
-        {
-            return APIRequestAsync<AuthSigninResponse>(new Tuple<string, string>[] { 
-                new Tuple<string,string>("user", userId),
-                new Tuple<string,string>("team", teamId),
-                new Tuple<string,string>("password", password)
-            }, new Tuple<string, string>[0]);
         }
 
         public Task<AuthTestResponse> TestAuthAsync()
@@ -555,11 +497,10 @@ namespace SlackAPI
 
             parameters.Add(string.Format("{0}={1}", "channels", string.Join(",", channelIds)));
 
-            using(HttpClient client = new HttpClient())
             using (MultipartFormDataContent form = new MultipartFormDataContent())
             {
                 form.Add(new ByteArrayContent(fileData), "file", fileName);
-                HttpResponseMessage response = client.PostAsync(string.Format("{0}?{1}", target, string.Join("&", parameters.ToArray())), form).Result;
+                HttpResponseMessage response = PostRequest(string.Format("{0}?{1}", target, string.Join("&", parameters.ToArray())), form);
                 string result = response.Content.ReadAsStringAsync().Result;
                 //callback(JsonConvert.DeserializeObject<FileUploadResponse>(result, new JavascriptDateTimeConverter()));
                 throw new NotImplementedException("This operation has not been implemented.");


### PR DESCRIPTION
This PR introduces full proxy support for SlackClient, SlackTaskClient and SlackSocketClient and supersede #133.

I had to do some changes and API breaks to be able to pass a IWebProxy instance in SlackClient/SlackTaskClient and SlackSocketClient constructors. Most of the changes are only code move. I added comments on real changes

- SlackClientBase is created and contains generic web access methods (HttpWebRequest/HttpClient with proxy support)
- SlackClient and SlackTaskClient inherit SlackClientBase
- SlackSocket is updated with proxy support
- [API BREAK] SlackSocketHelpers class is created and contains the old public static methods from SlackClient converted to instance methods
  - void StartAuth(Action<AuthStartResponse> callback, string email)
  - Task<AuthStartResponse> StartAuthAsync(string email)
  - void FindTeam(Action<FindTeamResponse> callback, string team)
  - Task<FindTeamResponse> FindTeam(string team)
  - void AuthSignin(Action<AuthSigninResponse> callback, string userId, string teamId, string password)
  - Task<AuthSigninResponse> AuthSignin(string userId, string teamId, string password)
  - Uri GetAuthorizeUri(string clientId, SlackScope scopes, string redirectUri = null, string state = null, string team = null)
  - void GetAccessToken(Action<AccessTokenResponse> callback, string clientId, string clientSecret, string redirectUri, string code)

Because of these changes, I think the next SlackAPI version should be labelled 1.1.0