### PR TITLE
Support Select Lists

### DIFF
--- a/SlackAPI.Tests/Helpers/SlackMother.cs
+++ b/SlackAPI.Tests/Helpers/SlackMother.cs
@@ -45,13 +45,14 @@
                 },
                 actions = new []
                 {
-                    new AttachmentAction("Button 1", "Button 1 Text") ,
-                    new AttachmentAction("Button 2", "Button 2 Text") {style = "primary"},
-                    new AttachmentAction("Button 3", "Button 3 Text") {style = "danger"},
-                    new AttachmentAction("Button 4", "Button 4 Text") {style = "danger", confirm = new ActionConfirm {text = "Are you sure?????"} },
-                    new AttachmentAction("Button 5", "Button 5 Text") {style = "danger", confirm = new ActionConfirm {text = "Do you really want to do this", dismiss_text = "No I don't", ok_text = "Sure I do", title = "Just checking"} }
+                    new AttachmentAction(AttachmentActionTypeEnum.Button, "Button 1", "Button 1 Text") ,
+                    new AttachmentAction(AttachmentActionTypeEnum.Button, "Button 2", "Button 2 Text") {style = AttachmentActionStyleEnum.Primary },
+                    new AttachmentAction(AttachmentActionTypeEnum.Button, "Button 3", "Button 3 Text") {style = AttachmentActionStyleEnum.Danger },
+                    new AttachmentAction(AttachmentActionTypeEnum.Button, "Button 4", "Button 4 Text") {style = AttachmentActionStyleEnum.Danger, confirm = new ActionConfirm {text = "Are you sure?????"} },
+                    new AttachmentAction(AttachmentActionTypeEnum.Button, "Button 5", "Button 5 Text") {style = AttachmentActionStyleEnum.Danger, confirm = new ActionConfirm {text = "Do you really want to do this", dismiss_text = "No I don't", ok_text = "Sure I do", title = "Just checking"}
                 }
             }
-        };
+        }
+    };
     }
 }

--- a/SlackAPI/Attachment.cs
+++ b/SlackAPI/Attachment.cs
@@ -1,4 +1,6 @@
-﻿namespace SlackAPI
+﻿using System.Collections.Generic;
+
+namespace SlackAPI
 {
     //See: https://api.slack.com/docs/attachments
     public class Attachment
@@ -28,22 +30,6 @@
         public string title;
         public string value;
         public bool @short;
-    }
-
-    //See: https://api.slack.com/docs/message-buttons#action_fields
-    public class AttachmentAction
-    {
-        public AttachmentAction(string name, string text)
-        {
-            this.name = name;
-            this.text = text;
-        }
-        public string name { get; }
-        public string text { get; }
-        public string style;
-        public string type = "button";
-        public string value;
-        public ActionConfirm confirm;
     }
 
     //see: https://api.slack.com/docs/message-buttons#confirmation_fields

--- a/SlackAPI/AttachmentAction.cs
+++ b/SlackAPI/AttachmentAction.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using SlackAPI.JsonConverter;
+
+namespace SlackAPI
+{
+    //See: https://api.slack.com/docs/message-buttons#action_fields
+    public class AttachmentAction
+    {
+        public AttachmentAction(AttachmentActionTypeEnum actionType, string name, string text)
+        {
+            this.type = actionType;
+            this.name = name;
+            this.text = text;
+        }
+
+        public string name { get; }
+        public string text { get; }
+
+        [JsonConverter(typeof(AttachmentActionStyleConverter))]
+        public AttachmentActionStyleEnum style;
+
+        [JsonConverter(typeof(AttachmentActionTypeConverter))]
+        public AttachmentActionTypeEnum type;
+
+        public string value;
+
+        public AttachmentActionOption[] options;
+
+        public ActionConfirm confirm;
+    }
+
+    public enum AttachmentActionStyleEnum
+    {
+        Default,
+        Primary,
+        Danger
+    }
+
+    public enum AttachmentActionTypeEnum
+    {
+        Button,
+        Select
+    }
+}

--- a/SlackAPI/AttachmentActionOption.cs
+++ b/SlackAPI/AttachmentActionOption.cs
@@ -1,0 +1,14 @@
+﻿namespace SlackAPI
+{
+    //See: https://api.slack.com/docs/message-menus
+    public class AttachmentActionOption
+    {
+        public AttachmentActionOption(string text, string value)
+        {
+            this.text = text;
+            this.value = value;
+        }
+        public string text { get; }
+        public string value;
+    }
+}

--- a/SlackAPI/Extensions.cs
+++ b/SlackAPI/Extensions.cs
@@ -6,7 +6,7 @@ namespace SlackAPI
 {
     public static class Extensions
     {
-        internal static readonly IList<JsonConverter> Converters = new List<JsonConverter> { new JavascriptDateTimeConverter() };
+        internal static readonly IList<Newtonsoft.Json.JsonConverter> Converters = new List<Newtonsoft.Json.JsonConverter> { new JavascriptDateTimeConverter() };
 
         /// <summary>
         /// Converts to a propert JavaScript timestamp interpretted by Slack.  Also handles converting to UTC.

--- a/SlackAPI/JsonConverter/AttachmentActionStyleConverter.cs
+++ b/SlackAPI/JsonConverter/AttachmentActionStyleConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+
+namespace SlackAPI.JsonConverter
+{
+    public class AttachmentActionStyleConverter : Newtonsoft.Json.JsonConverter
+    {
+
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (AttachmentActionStyleEnum)Enum.Parse(typeof(AttachmentActionStyleEnum), reader.Value.ToString(), true);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            AttachmentActionStyleEnum style = (AttachmentActionStyleEnum)Enum.Parse(typeof(AttachmentActionStyleEnum), value.ToString());
+
+            writer.WriteValue(style.ToString().ToLower());
+        }
+    }
+}

--- a/SlackAPI/JsonConverter/AttachmentActionTypeConverter.cs
+++ b/SlackAPI/JsonConverter/AttachmentActionTypeConverter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+
+namespace SlackAPI.JsonConverter
+{
+    public class AttachmentActionTypeConverter : Newtonsoft.Json.JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            return (AttachmentActionTypeEnum)Enum.Parse(typeof(AttachmentActionTypeEnum), reader.Value.ToString(), true);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            AttachmentActionTypeEnum type = (AttachmentActionTypeEnum)Enum.Parse(typeof(AttachmentActionTypeEnum), value.ToString());
+
+            writer.WriteValue(type.ToString().ToLower());
+        }
+    }
+}

--- a/SlackAPI/SlackAPI.csproj
+++ b/SlackAPI/SlackAPI.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 

--- a/SlackAPI/SlackAPI.csproj
+++ b/SlackAPI/SlackAPI.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
@@ -29,6 +29,10 @@
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
 </Project>

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -493,7 +493,7 @@ namespace SlackAPI
             if (attachments != null && attachments.Length > 0)
                 parameters.Add(new Tuple<string, string>("attachments", JsonConvert.SerializeObject(attachments)));
 
-            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+                parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
 
             APIRequestWithToken(callback, parameters.ToArray());
         }

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -11,7 +11,7 @@ using SlackAPI.RPCMessages;
 namespace SlackAPI
 {
     /// <summary>
-    /// SlackClient is intended to solely handle RPC (HTTP-based) functionality. Does not handle WebSocket connectivity.
+    /// SlackClient is intendedfty. Does not handle WebSocket connectivity.
     ///
     /// For WebSocket connectivity, refer to <see cref="SlackAPI.SlackSocketClient"/>
     /// </summary>
@@ -516,46 +516,46 @@ namespace SlackAPI
             string icon_url = null,
             string icon_emoji = null,
             bool? as_user = null,
-	          string thread_ts = null)
-        {
-            List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
+	        string thread_ts = null)
+            {
+                List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
 
-            parameters.Add(new Tuple<string,string>("channel", channelId));
-            parameters.Add(new Tuple<string,string>("text", text));
+                parameters.Add(new Tuple<string,string>("channel", channelId));
+                parameters.Add(new Tuple<string,string>("text", text));
 
-            if(!string.IsNullOrEmpty(botName))
-                parameters.Add(new Tuple<string,string>("username", botName));
+                if(!string.IsNullOrEmpty(botName))
+                    parameters.Add(new Tuple<string,string>("username", botName));
 
-            if (!string.IsNullOrEmpty(parse))
-                parameters.Add(new Tuple<string, string>("parse", parse));
+                if (!string.IsNullOrEmpty(parse))
+                    parameters.Add(new Tuple<string, string>("parse", parse));
 
-            if (linkNames)
-                parameters.Add(new Tuple<string, string>("link_names", "1"));
+                if (linkNames)
+                    parameters.Add(new Tuple<string, string>("link_names", "1"));
 
-            if (attachments != null && attachments.Length > 0)
-                parameters.Add(new Tuple<string, string>("attachments",
-                    JsonConvert.SerializeObject(attachments, Formatting.None,
-                            new JsonSerializerSettings // Shouldn't include a not set property
-                            {
-                                NullValueHandling = NullValueHandling.Ignore
-                            })));
+                if (attachments != null && attachments.Length > 0)
+                    parameters.Add(new Tuple<string, string>("attachments",
+                        JsonConvert.SerializeObject(attachments, Formatting.None,
+                                new JsonSerializerSettings // Shouldn't include a not set property
+                                {
+                                    NullValueHandling = NullValueHandling.Ignore
+                                })));
 
-            if (unfurl_links)
-                parameters.Add(new Tuple<string, string>("unfurl_links", "1"));
+                if (unfurl_links)
+                    parameters.Add(new Tuple<string, string>("unfurl_links", "1"));
 
-            if (!string.IsNullOrEmpty(icon_url))
-                parameters.Add(new Tuple<string, string>("icon_url", icon_url));
+                if (!string.IsNullOrEmpty(icon_url))
+                    parameters.Add(new Tuple<string, string>("icon_url", icon_url));
 
-            if (!string.IsNullOrEmpty(icon_emoji))
-                parameters.Add(new Tuple<string, string>("icon_emoji", icon_emoji));
+                if (!string.IsNullOrEmpty(icon_emoji))
+                    parameters.Add(new Tuple<string, string>("icon_emoji", icon_emoji));
 
-            if (as_user.HasValue)
-                parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+                if (as_user.HasValue)
+                    parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
 
-            if (!string.IsNullOrEmpty(thread_ts))
-                parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+                if (!string.IsNullOrEmpty(thread_ts))
+                    parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
 
-            APIRequestWithToken(callback, parameters.ToArray());
+                APIRequestWithToken(callback, parameters.ToArray());
         }
 
         public void PostEphemeralMessage(

--- a/SlackAPI/SlackClientBase.cs
+++ b/SlackAPI/SlackClientBase.cs
@@ -110,7 +110,7 @@ namespace SlackAPI
             return httpClient.PostAsync(requestUri, form).Result;
         }
 
-        public void RegisterConverter(JsonConverter converter)
+        public void RegisterConverter(Newtonsoft.Json.JsonConverter converter)
         {
             if (converter == null)
             {

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using SlackAPI.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
When adding attachment options, you can now include Select Lists, not just buttons. I added an enum to support the type of Select option and attribute converters to make creating Attachment Options easier.