### PR TITLE
Updated AccessTokenResponse to include the BotTokenResponse and team_id

### DIFF
--- a/SlackAPI/RPCMessages/AccessTokenResponse.cs
+++ b/SlackAPI/RPCMessages/AccessTokenResponse.cs
@@ -12,6 +12,24 @@ namespace SlackAPI
         public string access_token;
         public string scope;
         public string team_name;
-        public Bot bot;
+        public string team_id { get; set; }
+        public BotTokenResponse bot;
+    }
+
+    public class BotTokenResponse
+    {
+       public string emoji;
+       public string image_24;
+       public string image_32;
+       public string image_48;
+       public string image_72;
+       public string image_192;
+
+       public bool deleted;
+       public UserProfile icons;
+       public string id;
+       public string name;
+       public string bot_user_id;
+       public string bot_access_token;
     }
 }


### PR DESCRIPTION
The bot class referenced by the AccessTokenResponse had been made specific to the user pull and no longer reflected the access token response returned from slack