### PR TITLE
Fixes timestamp serialization issue (#170)

### DIFF
--- a/SlackAPI/Extensions.cs
+++ b/SlackAPI/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Newtonsoft.Json;
 
 namespace SlackAPI
@@ -17,10 +18,10 @@ namespace SlackAPI
         {
             if (toUTC)
             {
-                return ((that.ToUniversalTime().Ticks - 621355968000000000m) / 10000000m).ToString("F6");
+                return ((that.ToUniversalTime().Ticks - 621355968000000000m) / 10000000m).ToString("F6", CultureInfo.InvariantCulture);
             }
             else
-                return that.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString();
+                return that.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture);
         }
 
         public static K Deserialize<K>(this string data)

--- a/SlackAPI/JavascriptDateTimeConverter.cs
+++ b/SlackAPI/JavascriptDateTimeConverter.cs
@@ -20,7 +20,7 @@ namespace SlackAPI
             DateTime res = new DateTime(621355968000000000 + (long)(value * 10000000m)).ToLocalTime();
             System.Diagnostics.Debug.Assert(
                 Decimal.Equals(
-                    Decimal.Parse(res.ToProperTimeStamp()), 
+                    Decimal.Parse(res.ToProperTimeStamp(), CultureInfo.InvariantCulture), 
                     Decimal.Parse(reader.Value.ToString(), CultureInfo.InvariantCulture)), 
                 "Precision loss :(");
             return res;


### PR DESCRIPTION
This should fix #170. The changes are:
* Using invariant culture to serialize timestamps
* Corresponding change to the Assert expression (the expression relates on the timestamp serialization options).
