### PR TITLE
Added not_set to SearchSort to make the library able to connect to Slack again

### DIFF
--- a/SlackAPI/RPCMessages/SearchResponseMessages.cs
+++ b/SlackAPI/RPCMessages/SearchResponseMessages.cs
@@ -55,6 +55,7 @@ namespace SlackAPI
 
     public enum SearchSort
     {
+        not_set,
         score,
         timestamp
     }


### PR DESCRIPTION
Currently this error is thrown when ConnectAsync is called:

> Error converting value "not_set" to type 'SlackAPI.SearchSort'. Path 'self.prefs.search_sort', line 1, position 336.

This is due to Slack adding new sort option called not_set to it's API. This commit introduces this new sort type to this library.