### PR TITLE
Added not_set_new_user enum

### DIFF
--- a/SlackAPI/RPCMessages/SearchResponseMessages.cs
+++ b/SlackAPI/RPCMessages/SearchResponseMessages.cs
@@ -57,7 +57,8 @@ namespace SlackAPI
     {
         not_set,
         score,
-        timestamp
+        timestamp,
+        not_set_new_user
     }
 
     public enum SearchSortDirection


### PR DESCRIPTION
When you create a new user and hook up to Slack using this library, I get a similar error as in https://github.com/Inumedia/SlackAPI/issues/177 but with `not_set_new_user` instead. This PR fixes this error by adding the `not_set_new_user` enum to the `SearchResponseMessages` class.