### PR TITLE
Adds channels.invite API request

### DIFF
--- a/SlackAPI/RPCMessages/ChannelInviteResponse.cs
+++ b/SlackAPI/RPCMessages/ChannelInviteResponse.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackAPI
+{
+    [RequestPath("channels.invite")]
+    public class ChannelInviteResponse : Response
+    {
+    }
+}

--- a/SlackAPI/RPCMessages/ChannelInviteResponse.cs
+++ b/SlackAPI/RPCMessages/ChannelInviteResponse.cs
@@ -9,5 +9,6 @@ namespace SlackAPI
     [RequestPath("channels.invite")]
     public class ChannelInviteResponse : Response
     {
+        public Channel channel;
     }
 }

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -127,10 +127,22 @@ namespace SlackAPI
         {
             APIRequestWithToken(callback);
         }
+
 		public void ChannelsCreate(Action<ChannelCreateResponse> callback, string name) {
 			APIRequestWithToken(callback, new Tuple<string, string>("name", name));
 		}
-		public void GetChannelList(Action<ChannelListResponse> callback, bool ExcludeArchived = true)
+
+        public void ChannelsInvite(Action<ChannelInviteResponse> callback, string userId, string channelId)
+        {
+            List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
+
+            parameters.Add(new Tuple<string, string>("channel", channelId));
+            parameters.Add(new Tuple<string, string>("user", userId));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
+
+        public void GetChannelList(Action<ChannelListResponse> callback, bool ExcludeArchived = true)
         {
             APIRequestWithToken(callback, new Tuple<string, string>("exclude_archived", ExcludeArchived ? "1" : "0"));
         }

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -112,6 +112,16 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<ChannelCreateResponse>(new Tuple<string, string>("name", name));
         }
 
+        public Task<ChannelInviteResponse> ChannelsInviteAsync(string userId, string channelId)
+        {
+            List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
+
+            parameters.Add(new Tuple<string, string>("channel", channelId));
+            parameters.Add(new Tuple<string, string>("user", userId));
+
+            return APIRequestWithTokenAsync<ChannelInviteResponse>(parameters.ToArray());
+        }
+
         public Task<ChannelListResponse> GetChannelListAsync(bool ExcludeArchived = true)
         {
             return APIRequestWithTokenAsync<ChannelListResponse>(new Tuple<string, string>("exclude_archived", ExcludeArchived ? "1" : "0"));


### PR DESCRIPTION
This adds the ability to call [channels.invite](https://api.slack.com/methods/channels.invite)

Closes #195 