### PR TITLE
Fixed presence_changed support

### DIFF
--- a/SlackAPI.Tests/Configuration/IntegrationFixture.cs
+++ b/SlackAPI.Tests/Configuration/IntegrationFixture.cs
@@ -45,9 +45,9 @@ namespace SlackAPI.Tests.Configuration
             }
         }
 
-        public SlackSocketClient CreateUserClient(IWebProxy proxySettings = null, bool subscribePresenceChanges = false)
+        public SlackSocketClient CreateUserClient(IWebProxy proxySettings = null, bool maintainPresenceChangesStatus = false)
         {
-            return this.CreateClient(this.Config.UserAuthToken, proxySettings, subscribePresenceChanges);
+            return this.CreateClient(this.Config.UserAuthToken, proxySettings, maintainPresenceChangesStatus);
         }
 
         public SlackSocketClient CreateBotClient(IWebProxy proxySettings = null)

--- a/SlackAPI.Tests/Configuration/IntegrationFixture.cs
+++ b/SlackAPI.Tests/Configuration/IntegrationFixture.cs
@@ -45,9 +45,9 @@ namespace SlackAPI.Tests.Configuration
             }
         }
 
-        public SlackSocketClient CreateUserClient(IWebProxy proxySettings = null)
+        public SlackSocketClient CreateUserClient(IWebProxy proxySettings = null, bool subscribePresenceChanges = false)
         {
-            return this.CreateClient(this.Config.UserAuthToken, proxySettings);
+            return this.CreateClient(this.Config.UserAuthToken, proxySettings, subscribePresenceChanges);
         }
 
         public SlackSocketClient CreateBotClient(IWebProxy proxySettings = null)
@@ -83,7 +83,7 @@ namespace SlackAPI.Tests.Configuration
             return JsonConvert.DeserializeAnonymousType(json, jsonObject).slack;
         }
 
-        private SlackSocketClient CreateClient(string authToken, IWebProxy proxySettings = null)
+        private SlackSocketClient CreateClient(string authToken, IWebProxy proxySettings = null, bool subscribePresenceChanges = false)
         {
             SlackSocketClient client;
 
@@ -92,7 +92,7 @@ namespace SlackAPI.Tests.Configuration
             using (var syncClientSocket = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected callback"))
             using (var syncClientSocketHello = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected hello callback"))
             {
-                client = new SlackSocketClient(authToken, proxySettings);
+                client = new SlackSocketClient(authToken, proxySettings, subscribePresenceChanges);
                 client.OnHello += () => syncClientSocketHello.Proceed();
                 client.Connect(x =>
                 {

--- a/SlackAPI.Tests/Configuration/IntegrationFixture.cs
+++ b/SlackAPI.Tests/Configuration/IntegrationFixture.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using System.Net;
 using System.Reflection;
-using System.Threading;
 using Newtonsoft.Json;
 using SlackAPI.Tests.Helpers;
 using Xunit;
@@ -83,7 +82,7 @@ namespace SlackAPI.Tests.Configuration
             return JsonConvert.DeserializeAnonymousType(json, jsonObject).slack;
         }
 
-        private SlackSocketClient CreateClient(string authToken, IWebProxy proxySettings = null, bool subscribePresenceChanges = false)
+        private SlackSocketClient CreateClient(string authToken, IWebProxy proxySettings = null, bool maintainPresenceChanges = false)
         {
             SlackSocketClient client;
 
@@ -92,7 +91,7 @@ namespace SlackAPI.Tests.Configuration
             using (var syncClientSocket = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected callback"))
             using (var syncClientSocketHello = new InSync($"{nameof(SlackClient.Connect)} - SocketConnected hello callback"))
             {
-                client = new SlackSocketClient(authToken, proxySettings, subscribePresenceChanges);
+                client = new SlackSocketClient(authToken, proxySettings, maintainPresenceChanges);
                 client.OnHello += () => syncClientSocketHello.Proceed();
                 client.Connect(x =>
                 {

--- a/SlackAPI/WebSocketMessages/ManualPresenceChange.cs
+++ b/SlackAPI/WebSocketMessages/ManualPresenceChange.cs
@@ -1,0 +1,7 @@
+﻿namespace SlackAPI.WebSocketMessages
+{
+    [SlackSocketRouting("manual_presence_change")]
+    public class ManualPresenceChange : PresenceChange
+    {
+    }
+}

--- a/SlackAPI/WebSocketMessages/PresenceChange.cs
+++ b/SlackAPI/WebSocketMessages/PresenceChange.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace SlackAPI.WebSocketMessages
+﻿namespace SlackAPI.WebSocketMessages
 {
     [SlackSocketRouting("presence_change")]
     public class PresenceChange : SlackSocketMessage

--- a/SlackAPI/WebSocketMessages/PresenceChangeSubscription.cs
+++ b/SlackAPI/WebSocketMessages/PresenceChangeSubscription.cs
@@ -1,0 +1,15 @@
+﻿using System.Linq;
+
+namespace SlackAPI.WebSocketMessages
+{
+    [SlackSocketRouting("presence_sub")]
+    public class PresenceChangeSubscription : SlackSocketMessage
+    {
+        public PresenceChangeSubscription(string[] usersIds)
+        {
+            this.ids = usersIds;
+        }
+
+        public string[] ids { get; }
+    }
+}


### PR DESCRIPTION
Presence changes support is broken in SlackApi probably because of changes on Slack in January 2018 (https://api.slack.com/events/presence_change).

- I introduced a flag in the ctor to synchronize presence changes in the users lookup table. It's an opt-in option because it can have a negative impact on performance.
- I introduced a `SubscribePresenceChange` method to subscribe changes only for specific users
- I added `OnPresenceChanged` event
- I added support of `manual_presence_change` event (same `OnPresenceChanged` event is raised)
- I fixed the `SendPresence` method (the argument was not used)
- I added few unit tests