### PR TITLE
Only provide as_user parameter if set to true

### DIFF
--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -530,7 +530,8 @@ namespace SlackAPI
             if (!string.IsNullOrEmpty(icon_emoji))
                 parameters.Add(new Tuple<string, string>("icon_emoji", icon_emoji));
 
-            parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+            if (as_user)
+                parameters.Add(new Tuple<string, string>("as_user", true.ToString()));
 
             return APIRequestWithTokenAsync<PostMessageResponse>(parameters.ToArray());
         }


### PR DESCRIPTION
Per https://api.slack.com/methods/chat.postMessage#arguments :

The `as_user` parameter may not be used with newer bot tokens. For such newer tokens, whenever `as_user` is supplied, the request will fail with "invalid_arguments" (even when false). 

As the default is false we can only provide it if it's set to true, and it should still preserve compatibility. 