### PR TITLE
Force TLS1.2 support as requested by Slack

### DIFF
--- a/SlackAPI.Tests/UserUIInteraction.cs
+++ b/SlackAPI.Tests/UserUIInteraction.cs
@@ -10,6 +10,9 @@ using Xunit;
 
 namespace SlackAPI.Tests
 {
+// Run UI tests on a single plateform to avoid Slack Captcha
+// (captcha is displayed when trying to login too often)
+#if NETFRAMEWORK
     [Collection("Integration tests")]
     public class UserUIInteraction
     {
@@ -70,4 +73,5 @@ namespace SlackAPI.Tests
             return accessTokenResponse;
         }
     }
+#endif
 }

--- a/SlackAPI/SlackClientBase.cs
+++ b/SlackAPI/SlackClientBase.cs
@@ -14,6 +14,14 @@ namespace SlackAPI
         private readonly HttpClient httpClient;
         public string APIBaseLocation { get; set; } = "https://slack.com/api/";
 
+        static SlackClientBase()
+        {
+#if !NETSTANDARD1_3 && !NETSTANDARD1_6
+            // Force Tls 1.2 for Slack
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+#endif
+        }
+
         protected SlackClientBase()
         {
             this.httpClient = new HttpClient();


### PR DESCRIPTION
According #218 and https://slack.com/intl/en-sg/help/articles/360024438834-Transport-Layer-Security--TLS--in-Slack , TLS 1.0 and 1.1 are not supported anymore by Slack