### PR TITLE
Allow explicit unfurl_links = false

### DIFF
--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -543,7 +543,7 @@ namespace SlackAPI
             bool linkNames = false,
             IBlock[] blocks = null,
             Attachment[] attachments = null,
-            bool unfurl_links = false,
+            bool? unfurl_links = null,
             string icon_url = null,
             string icon_emoji = null,
             bool? as_user = null,
@@ -579,8 +579,8 @@ namespace SlackAPI
                                    NullValueHandling = NullValueHandling.Ignore
                                })));
 
-         if (unfurl_links)
-                parameters.Add(new Tuple<string, string>("unfurl_links", "1"));
+            if (unfurl_links.HasValue)
+                parameters.Add(new Tuple<string, string>("unfurl_links", unfurl_links.Value ? "true" : "false"));
 
             if (!string.IsNullOrEmpty(icon_url))
                 parameters.Add(new Tuple<string, string>("icon_url", icon_url));

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -488,7 +488,7 @@ namespace SlackAPI
             bool linkNames = false,
             IBlock[] blocks = null,
             Attachment[] attachments = null,
-            bool unfurl_links = false,
+            bool? unfurl_links = null,
             string icon_url = null,
             string icon_emoji = null,
             bool as_user = false)
@@ -521,8 +521,8 @@ namespace SlackAPI
                          NullValueHandling = NullValueHandling.Ignore
                       })));
 
-         if (unfurl_links)
-                parameters.Add(new Tuple<string, string>("unfurl_links", "1"));
+            if (unfurl_links.HasValue)
+                parameters.Add(new Tuple<string, string>("unfurl_links", unfurl_links.Value ? "true" : "false"));
 
             if (!string.IsNullOrEmpty(icon_url))
                 parameters.Add(new Tuple<string, string>("icon_url", icon_url));


### PR DESCRIPTION
unfurl_links is only included in API request if set to `true`. Because Slack will do some unfurling by default unless you explicitly tell them not to, we should have a way of providing this.