### PR TITLE
Used GitVersion to generate versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,6 +225,9 @@ packages
 *.lock.json
 
 # Cake
-tools/
+tools/*
+!tools/packages.config
+
+
 .vs/
 artifacts/

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,5 @@
 ﻿<Project>
     <PropertyGroup>
-        <VersionPrefix>1.1.0</VersionPrefix>
-        <!-- VersionSuffix is computed in build.cake depending of the type of the build -->
-        <VersionSuffix>dev.0+sha.0</VersionSuffix>
-
         <Description>A Slack wrapper for direct interaction with their APIs.</Description>
         <Copyright>Inumedia - Copyright ©  2018</Copyright>
         <AssemblyProduct>SlackAPI</AssemblyProduct>
@@ -15,5 +11,9 @@
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <RepositoryType>git</RepositoryType>
         <RepositoryUrl>https://github.com/Inumedia/SlackAPI</RepositoryUrl>
+
+        <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+        <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
     </PropertyGroup>
 </Project>

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyInformationalVersion("1.1.0.0")]

--- a/SlackAPI.Tests/SlackAPI.Tests.csproj
+++ b/SlackAPI.Tests/SlackAPI.Tests.csproj
@@ -30,6 +30,12 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/SlackAPI.sln
+++ b/SlackAPI.sln
@@ -7,6 +7,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackAPI", "SlackAPI\SlackA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackAPI.Tests", "SlackAPI.Tests\SlackAPI.Tests.csproj", "{DEFA9559-0F8F-4C38-9644-67A080EDC46D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution items", "{532C9828-A2CC-4281-950A-248B06D42E9C}"
+ProjectSection(SolutionItems) = preProject
+	appveyor.yml = appveyor.yml
+	build.cake = build.cake
+	Directory.Build.props = Directory.Build.props
+	GlobalAssemblyInfo.cs = GlobalAssemblyInfo.cs
+	README.md = README.md
+EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/SlackAPI/SlackAPI.csproj
+++ b/SlackAPI/SlackAPI.csproj
@@ -27,6 +27,12 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);RELEASE</DefineConstants>
   </PropertyGroup>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="Cake" version="0.37.0" />
+</packages>


### PR DESCRIPTION
I noticed the version in the SlackAPI assembly version doesn't match the nuget version.

I changed the Cake script to use GitVersion to automatically generate the version (instead of using the version from Directory.Build.props). To bump the version, you just have to add a tag once a version is released (https://gitversion.readthedocs.io/en/latest/input/docs/more-info/version-increments/).
