### PR TITLE
Adding users.lookupByEmail request method

### DIFF
--- a/SlackAPI/RPCMessages/UserEmailLookupResponse.cs
+++ b/SlackAPI/RPCMessages/UserEmailLookupResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace SlackAPI.RPCMessages
+{
+    [RequestPath("users.lookupByEmail")]
+    public class UserEmailLookupResponse : Response
+    {
+        public User user;
+    }
+}

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -128,7 +128,12 @@ namespace SlackAPI
             APIRequestWithToken(callback);
         }
 
-		public void ChannelsCreate(Action<ChannelCreateResponse> callback, string name) {
+        public void GetUserByEmail(Action<UserEmailLookupResponse> callback, string email)
+        {
+            APIRequestWithToken(callback, new Tuple<string, string>("email", email));
+        }
+
+        public void ChannelsCreate(Action<ChannelCreateResponse> callback, string name) {
 			APIRequestWithToken(callback, new Tuple<string, string>("name", name));
 		}
 

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -108,6 +108,11 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<UserListResponse>();
         }
 
+        public Task<UserEmailLookupResponse> GetUserByEmailAsync(string email)
+        {
+            return APIRequestWithTokenAsync<UserEmailLookupResponse>(new Tuple<string, string>("email", email));
+        }
+
         public Task<ChannelCreateResponse> ChannelsCreateAsync(string name) {
             return APIRequestWithTokenAsync<ChannelCreateResponse>(new Tuple<string, string>("name", name));
         }


### PR DESCRIPTION
Hello
Thank you for creating this library! I'm using it in one of my projects and it's been very helpful. 
I was needing to make the following request [users.lookupByEmail](https://api.slack.com/methods/users.lookupByEmail) and noticed that the project doesn't have it implemented. 
So,  instead of opening an issue, I decided to include it myself.
Let me know if I need to do anything else to merge this pull request.