### PR TITLE
Add event for ConnectionLost

### DIFF
--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -15,6 +15,7 @@ namespace SlackAPI
         public event Action<ReactionAdded> OnReactionAdded;
         public event Action<Pong> OnPongReceived;
         public event Action<PresenceChange> OnPresenceChanged;
+	public event Action OnConnectionLost;
 
         bool HelloReceived;
         public const int PingInterval = 3000;
@@ -50,6 +51,12 @@ namespace SlackAPI
 
         public void ConnectSocket(Action onSocketConnected){
             underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected, this.proxySettings);
+	    underlyingSocket.ConnectionClosed += UnderlyingSocket_ConnectionClosed;
+        }
+	
+	private void UnderlyingSocket_ConnectionClosed()
+        {
+            OnConnectionLost?.Invoke();
         }
 
         public void ErrorReceiving<K>(Action<WebSocketException> callback)

--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -15,7 +15,7 @@ namespace SlackAPI
         public event Action<ReactionAdded> OnReactionAdded;
         public event Action<Pong> OnPongReceived;
         public event Action<PresenceChange> OnPresenceChanged;
-	public event Action OnConnectionLost;
+        public event Action OnConnectionLost;
 
         bool HelloReceived;
         public const int PingInterval = 3000;
@@ -51,10 +51,10 @@ namespace SlackAPI
 
         public void ConnectSocket(Action onSocketConnected){
             underlyingSocket = new SlackSocket(loginDetails, this, onSocketConnected, this.proxySettings);
-	    underlyingSocket.ConnectionClosed += UnderlyingSocket_ConnectionClosed;
+            underlyingSocket.ConnectionClosed += UnderlyingSocket_ConnectionClosed;
         }
-	
-	private void UnderlyingSocket_ConnectionClosed()
+        
+        private void UnderlyingSocket_ConnectionClosed()
         {
             OnConnectionLost?.Invoke();
         }


### PR DESCRIPTION
When the api stay running and there is for some reason a connection failure.
The SlackSocketClient is disconnected.
What I added is: An event to be notified when the connection is lost.
So,
After that we can retry to connect again :).