### PR TITLE
Add the attribute needed, provided

### DIFF
--- a/SlackAPI/Response.cs
+++ b/SlackAPI/Response.cs
@@ -17,6 +17,8 @@ namespace SlackAPI
         /// if ok is false, then this is the reason-code
         /// </summary>
         public string error;
+        public string needed;
+        public string provided;
 
         public void AssertOk()
         {


### PR DESCRIPTION
Some time when we have a connection failure, the error message need some information, ex: missing_scope
So we need to know what are the "needed" scope to add them.
with provided we can see what are the permission that we already provided to app.