### PR TITLE
Make stats_only_admins a nullable bool

### DIFF
--- a/SlackAPI/TeamPreferences.cs
+++ b/SlackAPI/TeamPreferences.cs
@@ -17,7 +17,7 @@ namespace SlackAPI
         public bool hide_referers;
         public int msg_edit_window_mins;
         public bool srvices_only_admins;
-        public bool stats_only_admins;
+        public bool? stats_only_admins;
 
         public enum AuthMode
         {


### PR DESCRIPTION
We're seeing this cause json deserialization exceptions when calling `SlackClient.ConnectAsync()` on one of our projects

`Error converting value {null} to type 'System.Boolean'. Path 'team.prefs.stats_only_admins'`