### PR TITLE
Pr/250 Expand #250 to Enum

### DIFF
--- a/SlackAPI.sln
+++ b/SlackAPI.sln
@@ -1,20 +1,20 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30320.27
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackAPI", "SlackAPI\SlackAPI.csproj", "{7EED3D9B-9B7A-49A4-AFBF-599153A47DDA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackAPI.Tests", "SlackAPI.Tests\SlackAPI.Tests.csproj", "{DEFA9559-0F8F-4C38-9644-67A080EDC46D}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution items", "Solution items", "{532C9828-A2CC-4281-950A-248B06D42E9C}"
-ProjectSection(SolutionItems) = preProject
-	appveyor.yml = appveyor.yml
-	build.cake = build.cake
-	Directory.Build.props = Directory.Build.props
-	GlobalAssemblyInfo.cs = GlobalAssemblyInfo.cs
-	README.md = README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
+		build.cake = build.cake
+		Directory.Build.props = Directory.Build.props
+		GlobalAssemblyInfo.cs = GlobalAssemblyInfo.cs
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/SlackAPI/Conversation.cs
+++ b/SlackAPI/Conversation.cs
@@ -6,14 +6,46 @@ using System.Threading.Tasks;
 
 namespace SlackAPI
 {
-    public class Conversation
-    {
-        public string id;
-        public DateTime created;
-        public DateTime last_read;
-        public bool is_open;
-        public bool is_starred;
-        public int unread_count;
-        public Message latest;
-    }
+	public class Conversation
+	{
+		public string id;
+		public DateTime created;
+		public DateTime last_read;
+		public bool is_open;
+		public bool is_starred;
+		public int unread_count;
+		public Message latest;
+
+		public static string ConversationTypesToQueryParam(ConversationTypes[] types)
+		{
+			//Translate the enum user-friendly names to API used names
+			List<string> typesAsString = new List<string>();
+			if (types.Contains(ConversationTypes.PublicChannel))
+			{
+				typesAsString.Add("public_channel");
+			}
+			if (types.Contains(ConversationTypes.PrivateChannel))
+			{
+				typesAsString.Add("private_channel");
+			}
+			if (types.Contains(ConversationTypes.GroupMessage))
+			{
+				typesAsString.Add("mpim");
+			}
+			if (types.Contains(ConversationTypes.DirectMessage))
+			{
+				typesAsString.Add("im");
+			}
+
+			return string.Join(",", types);
+		}
+	}
+
+	public enum ConversationTypes
+	{
+		PublicChannel, //public_channel
+		PrivateChannel, //private_channel
+		GroupMessage, //mpim
+		DirectMessage //im
+	}
 }

--- a/SlackAPI/RPCMessages/ConversationsListResponse.cs
+++ b/SlackAPI/RPCMessages/ConversationsListResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SlackAPI.RPCMessages
+{
+	[RequestPath("conversations.list")]
+	public class ConversationsListResponse : Response
+	{
+		public Channel[] channels;
+	}
+}

--- a/SlackAPI/Response.cs
+++ b/SlackAPI/Response.cs
@@ -25,5 +25,12 @@ namespace SlackAPI
             if (!(ok))
                 throw new InvalidOperationException(string.Format("An error occurred: {0}", this.error));
         }
+
+        public ResponseMetaData response_metadata;
+    }
+
+    public class ResponseMetaData
+    {
+	    public string next_cursor;
     }
 }

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -147,6 +147,22 @@ namespace SlackAPI
             APIRequestWithToken(callback, parameters.ToArray());
         }
 
+        public void GetConversationsList(Action<ConversationsListResponse> callback, string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        {
+	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
+	        {
+		        Tuple.Create("exclude_archived", ExcludeArchived ? "1" : "0")
+	        };
+	        if (limit > 0)
+		        Tuple.Create("limit", limit.ToString());
+            if (types.Any())
+		        Tuple.Create("types", string.Join(",", types));
+	        if (!string.IsNullOrEmpty(cursor))
+		        parameters.Add(new Tuple<string, string>("cursor", cursor));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
+
         public void GetChannelList(Action<ChannelListResponse> callback, bool ExcludeArchived = true)
         {
             APIRequestWithToken(callback, new Tuple<string, string>("exclude_archived", ExcludeArchived ? "1" : "0"));

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -147,7 +147,7 @@ namespace SlackAPI
             APIRequestWithToken(callback, parameters.ToArray());
         }
 
-        public void GetConversationsList(Action<ConversationsListResponse> callback, string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        public void GetConversationsList(Action<ConversationsListResponse> callback, string cursor = "", bool ExcludeArchived = true, int limit = 100, ConversationTypes[] types = null)
         {
 	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
 	        {
@@ -155,8 +155,8 @@ namespace SlackAPI
 	        };
 	        if (limit > 0)
 		        Tuple.Create("limit", limit.ToString());
-            if (types.Any())
-		        Tuple.Create("types", string.Join(",", types));
+            if (types != null && types.Any())
+		        Tuple.Create("types", Conversation.ConversationTypesToQueryParam(types));
 	        if (!string.IsNullOrEmpty(cursor))
 		        parameters.Add(new Tuple<string, string>("cursor", cursor));
 

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -127,6 +127,22 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<ChannelInviteResponse>(parameters.ToArray());
         }
 
+        public Task<ConversationsListResponse> GetConversationsListAsync(string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        {
+	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
+	        {
+		        Tuple.Create("exclude_archived", ExcludeArchived ? "1" : "0")
+	        };
+	        if (limit > 0)
+		        parameters.Add(Tuple.Create("limit", limit.ToString()));
+	        if (types != null && types.Any())
+		        parameters.Add(Tuple.Create("types", string.Join(",", types)));
+	        if (!string.IsNullOrEmpty(cursor))
+		        parameters.Add(new Tuple<string, string>("cursor", cursor));
+
+	        return APIRequestWithTokenAsync<ConversationsListResponse>(parameters.ToArray());
+        }
+
         public Task<ChannelListResponse> GetChannelListAsync(bool ExcludeArchived = true)
         {
             return APIRequestWithTokenAsync<ChannelListResponse>(new Tuple<string, string>("exclude_archived", ExcludeArchived ? "1" : "0"));

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -127,7 +127,7 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<ChannelInviteResponse>(parameters.ToArray());
         }
 
-        public Task<ConversationsListResponse> GetConversationsListAsync(string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        public Task<ConversationsListResponse> GetConversationsListAsync(string cursor = "", bool ExcludeArchived = true, int limit = 100, ConversationTypes[] types = null)
         {
 	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
 	        {
@@ -136,7 +136,7 @@ namespace SlackAPI
 	        if (limit > 0)
 		        parameters.Add(Tuple.Create("limit", limit.ToString()));
 	        if (types != null && types.Any())
-		        parameters.Add(Tuple.Create("types", string.Join(",", types)));
+		        parameters.Add(Tuple.Create("types", Conversation.ConversationTypesToQueryParam(types)));
 	        if (!string.IsNullOrEmpty(cursor))
 		        parameters.Add(new Tuple<string, string>("cursor", cursor));
 


### PR DESCRIPTION
Expands the improvements from #250 to use an enum instead of pure string for specifying requests to new Conversations endpoint for user-friendliness.