### PR TITLE
Fix for GetConversationsList() function requiring the parameter "type…

### DIFF
--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -154,8 +154,8 @@ namespace SlackAPI
 		        Tuple.Create("exclude_archived", ExcludeArchived ? "1" : "0")
 	        };
 	        if (limit > 0)
-		        parameters.Add(Tuple.Create("limit", limit.ToString())); 
-	        if (types.Any())
+		        parameters.Add(Tuple.Create("limit", limit.ToString()));
+            if ((types != null) && types.Any())
 		        parameters.Add(Tuple.Create("types", string.Join(",", types)));
 	        if (!string.IsNullOrEmpty(cursor))
 		        parameters.Add(Tuple.Create("cursor", cursor));


### PR DESCRIPTION
…s". According to the Slack API reference, this should be optional:

https://api.slack.com/methods/conversations.list