### PR TITLE
Alternative to pr/251. That method uses an enum with a function to tr…

### DIFF
--- a/SlackAPI/Conversation.cs
+++ b/SlackAPI/Conversation.cs
@@ -8,6 +8,14 @@ namespace SlackAPI
 {
     public class Conversation
     {
+        public enum Type
+        {
+            public_channel,
+            private_channel,
+            mpim,
+            im
+        }
+
         public string id;
         public DateTime created;
         public DateTime last_read;

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -147,7 +147,7 @@ namespace SlackAPI
             APIRequestWithToken(callback, parameters.ToArray());
         }
 
-        public void GetConversationsList(Action<ConversationsListResponse> callback, string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        public void GetConversationsList(Action<ConversationsListResponse> callback, string cursor = "", bool ExcludeArchived = true, int limit = 100, Conversation.Type[] types = null)
         {
 	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
 	        {
@@ -155,7 +155,7 @@ namespace SlackAPI
 	        };
 	        if (limit > 0)
 		        parameters.Add(Tuple.Create("limit", limit.ToString())); 
-	        if (types.Any())
+	        if (types != null && types.Any())
 		        parameters.Add(Tuple.Create("types", string.Join(",", types)));
 	        if (!string.IsNullOrEmpty(cursor))
 		        parameters.Add(Tuple.Create("cursor", cursor));

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -127,7 +127,7 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<ChannelInviteResponse>(parameters.ToArray());
         }
 
-        public Task<ConversationsListResponse> GetConversationsListAsync(string cursor = "", bool ExcludeArchived = true, int limit = 100, string[] types = null)
+        public Task<ConversationsListResponse> GetConversationsListAsync(string cursor = "", bool ExcludeArchived = true, int limit = 100, Conversation.Type[] types = null)
         {
 	        List<Tuple<string, string>> parameters = new List<Tuple<string, string>>()
 	        {


### PR DESCRIPTION
…anslate the names. My implementation names the enum values the actual API string values which eliminates the need for the extra ConversationTypesToQueryParam() function.

For example, instead of:
	Tuple.Create("types", Conversation.ConversationTypesToQueryParam(types));

We can leave this unchanged:
	parameters.Add(Tuple.Create("types", string.Join(",", types)));

This works because when string.Join translate types[] into strings, it calls ToString() which by default returns the enum element name.

This is also nice because we don't have to update the ConversationTypesToQueryParam() function whenever elements are added or removed from the enum.

If there is some kind of naming standard violation here, (e.g. The first enum element should be PublicChannel instead of public_channel), yet another alternative would be to use a class instead of an enum. For example:
public static class Type {
	public static readonly string PublicChannel = "public_channel";
	public static readonly string PrivateChannel = "private_channel";
	...
}

There is a detailed discussion on using friendly strings with enums on Stack Overflow here:
https://stackoverflow.com/questions/479410/enum-tostring-with-user-friendly-strings