### PR TITLE
Change im to use Conversations API.  DM API is being deprecated.

### DIFF
--- a/SlackAPI/RPCMessages/JoinDirectMessageChannelResponse.cs
+++ b/SlackAPI/RPCMessages/JoinDirectMessageChannelResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace SlackAPI
 {
-    [RequestPath("im.open")]
+    [RequestPath("conversations.open")]
     public class JoinDirectMessageChannelResponse : Response
     {
         public Channel channel;

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -551,7 +551,7 @@ namespace SlackAPI
 
         public void JoinDirectMessageChannel(Action<JoinDirectMessageChannelResponse> callback, string user)
         {
-            var param = new Tuple<string, string>("user", user);
+            var param = new Tuple<string, string>("users", user);
             APIRequestWithToken(callback, param);
         }
 


### PR DESCRIPTION
Slack is deprecating the im API.  This changes the direct message opening and sending to work through the conversations API instead.

Note: Additional changes should be made for other APIs that are being deprecated, but this was the only parts I was able to get time to fix.