### PR TITLE
Added attachments field to Message class

### DIFF
--- a/SlackAPI/Message.cs
+++ b/SlackAPI/Message.cs
@@ -16,6 +16,7 @@ namespace SlackAPI
         /// </summary>
         public string username;
         public string text;
+        public Attachment[] attachments;
         public bool is_starred;
         public string permalink;
         public Reaction[] reactions;


### PR DESCRIPTION
There is an attachments field in the response of the messages from Slack.
( see: https://api.slack.com/methods/conversations.history#responses )
However, the field does not exist in Message class.