### PR TITLE
Fixes for rtm.start deprecation

### DIFF
--- a/SlackAPI.Tests/Update.cs
+++ b/SlackAPI.Tests/Update.cs
@@ -69,7 +69,7 @@ namespace SlackAPI.Tests
             var client = this.fixture.UserClient;
             using (var sync = new InSync(nameof(SlackClient.EmitPresence)))
             {
-                client.EmitPresence((presence) =>
+                client.EmitPresence(presence =>
                 {
                     presence.AssertOk();
                     sync.Proceed();

--- a/SlackAPI.sln
+++ b/SlackAPI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30320.27
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32526.322
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SlackAPI", "SlackAPI\SlackAPI.csproj", "{7EED3D9B-9B7A-49A4-AFBF-599153A47DDA}"
 EndProject

--- a/SlackAPI/RPCMessages/BotInfoResponse.cs
+++ b/SlackAPI/RPCMessages/BotInfoResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace SlackAPI.RPCMessages
+{
+    [RequestPath("bots.info")]
+    public class BotInfoResponse : Response
+    {
+        public Bot bot;
+    }
+}

--- a/SlackAPI/RPCMessages/ChannelListResponse.cs
+++ b/SlackAPI/RPCMessages/ChannelListResponse.cs
@@ -3,6 +3,7 @@
 namespace SlackAPI
 {
     [RequestPath("channels.list")]
+    [Obsolete("Replaced by ConversationsListResponse", true)]
     public class ChannelListResponse : Response
     {
         public Channel[] channels;

--- a/SlackAPI/RPCMessages/ConversationsOpenResponse.cs
+++ b/SlackAPI/RPCMessages/ConversationsOpenResponse.cs
@@ -12,6 +12,5 @@ namespace SlackAPI
         public string no_op;
         public string already_open;
         public Channel channel;
-        public string error;
     }
 }

--- a/SlackAPI/RPCMessages/DialogOpenResponse.cs
+++ b/SlackAPI/RPCMessages/DialogOpenResponse.cs
@@ -9,11 +9,5 @@ namespace SlackAPI.RPCMessages
    [RequestPath("dialog.open")]
    public class DialogOpenResponse : Response
    {
-      public  ResponseMetadata response_metadata { get; set; }
-
-      public class ResponseMetadata
-      {
-         public string[] messages { get; set; }
-      }
    }
 }

--- a/SlackAPI/RPCMessages/DirectMessageConversationListResponse.cs
+++ b/SlackAPI/RPCMessages/DirectMessageConversationListResponse.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace SlackAPI
 {
     [RequestPath("im.list")]
+    [Obsolete("Replaced by ConversationsListResponse", true)]
     public class DirectMessageConversationListResponse : Response
     {
         public DirectMessageConversation[] ims;

--- a/SlackAPI/RPCMessages/GroupListResponse.cs
+++ b/SlackAPI/RPCMessages/GroupListResponse.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 namespace SlackAPI
 {
     [RequestPath("groups.list")]
+    [Obsolete("Replaced by ConversationsListResponse", true)]
     public class GroupListResponse : Response
     {
         public Channel[] groups;

--- a/SlackAPI/RPCMessages/LoginResponse.cs
+++ b/SlackAPI/RPCMessages/LoginResponse.cs
@@ -6,27 +6,17 @@ using System.Threading.Tasks;
 
 namespace SlackAPI
 {
-	[RequestPath("rtm.start")]
+	[RequestPath("rtm.connect")]
 	public class LoginResponse : Response
-	{
-		public Bot[] bots;
-		public Channel[] channels;
-		public Channel[] groups;
-		public DirectMessageConversation[] ims;
-		public Self self;
-		public int svn_rev;
-		public int min_svn_rev;
-		public Team team;
-		public string url;
-		public User[] users;
-	}
+    {
+        public string url;
+        public Team team;
+        public Self self;
+    }
 
     public class Self
     {
-        public DateTime created;
         public string id;
-        public string manual_presence;
         public string name;
-        public Preferences prefs;
     }
 }

--- a/SlackAPI/SlackClientBase.cs
+++ b/SlackAPI/SlackClientBase.cs
@@ -148,7 +148,7 @@ namespace SlackAPI
         {
             if (converter == null)
             {
-                throw new ArgumentNullException("converter");
+                throw new ArgumentNullException(nameof(converter));
             }
 
             Extensions.Converters.Add(converter);

--- a/SlackAPI/SlackSocket.cs
+++ b/SlackAPI/SlackSocket.cs
@@ -92,7 +92,7 @@ namespace SlackAPI
             currentId = 1;
 
             cts = new CancellationTokenSource();
-            socket.ConnectAsync(new Uri(string.Format("{0}?svn_rev={1}&login_with_boot_data-0-{2}&on_login-0-{2}&connect-1-{2}", loginDetails.url, loginDetails.svn_rev, DateTime.Now.Subtract(new DateTime(1970, 1, 1)).TotalSeconds)), cts.Token).Wait();
+            socket.ConnectAsync(new Uri(string.Format("{0}?login_with_boot_data-0-{1}&on_login-0-{1}&connect-1-{1}", loginDetails.url, DateTime.Now.Subtract(new DateTime(1970, 1, 1)).TotalSeconds)), cts.Token).Wait();
             if(onConnected != null)
                 onConnected();
             SetupReceiving();
@@ -136,7 +136,7 @@ namespace SlackAPI
         {
             int sendingId = Interlocked.Increment(ref currentId);
             message.id = sendingId;
-            callbacks.Add(sendingId, (c) =>
+            callbacks.Add(sendingId, c =>
             {
                 K obj = c.Deserialize<K>();
                 callback(obj);
@@ -232,7 +232,7 @@ namespace SlackAPI
                             continue;
                         }
 
-                        string data = string.Join("", buffers.Select((c) => Encoding.UTF8.GetString(c).TrimEnd('\0')));
+                        string data = string.Join("", buffers.Select(c => Encoding.UTF8.GetString(c).TrimEnd('\0')));
                         //Console.WriteLine("SlackSocket data = " + data);
                         SlackSocketMessage message = null;
                         try

--- a/SlackAPI/SlackSocketClient.cs
+++ b/SlackAPI/SlackSocketClient.cs
@@ -33,20 +33,23 @@ namespace SlackAPI
             this.maintainPresenceChanges = maintainPresenceChanges;
         }
 
-        public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null)
+        public override void Connect(Action<LoginResponse> onConnected, Action onSocketConnected = null, int timeoutSeconds = 60)
         {
-            base.Connect((s) => {
+            base.Connect(s => {
                 if (s.ok)
+                {
                     ConnectSocket(onSocketConnected);
+                    Connected(s, timeoutSeconds);
+                }
 
                 onConnected(s);
             });
         }
 
-        protected override void Connected(LoginResponse loginDetails)
+        protected override void Connected(LoginResponse login, int timeoutSeconds)
         {
-            this.loginDetails = loginDetails;
-            base.Connected(loginDetails);
+            this.loginDetails = login;
+            base.Connected(loginDetails, timeoutSeconds);
         }
 
         public void ConnectSocket(Action onSocketConnected){


### PR DESCRIPTION
I have been unable to test all the changes in this update but I attempted maintain the interface. Clearly this lib has a shelf life as slack what people to move to their maintained libs written in Java, JS & Python.

Hopefully if this passes the test it might help keep this lib alive for a bit longer.

I timeboxed this update so some of the code is not tested and have not run any unit tests as I do not have access to a non-business slack environment.