### PR TITLE
Added broadcast_reply feature

### DIFF
--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -678,8 +678,10 @@ namespace SlackAPI
             bool? unfurl_links = null,
             string icon_url = null,
             string icon_emoji = null,
-            bool? as_user = null,
-	          string thread_ts = null)
+            bool? as_user = null, 
+            string thread_ts = null, 
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
 
@@ -725,6 +727,9 @@ namespace SlackAPI
 
             if (!string.IsNullOrEmpty(thread_ts))
                 parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+            
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
 
             APIRequestWithToken(callback, parameters.ToArray());
         }
@@ -739,7 +744,9 @@ namespace SlackAPI
             Block[] blocks = null,
             Attachment[] attachments = null,
             bool as_user = false,
-	    string thread_ts = null)
+	        string thread_ts = null,
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
 
@@ -770,6 +777,12 @@ namespace SlackAPI
                             })));
 
             parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
+            
+            if (!string.IsNullOrEmpty(thread_ts))
+                parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+            
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
 
             APIRequestWithToken(callback, parameters.ToArray());
         }
@@ -789,7 +802,9 @@ namespace SlackAPI
             string icon_url = null,
             string icon_emoji = null,
             bool? as_user = null,
-              string thread_ts = null)
+            string thread_ts = null,
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
 
@@ -836,6 +851,9 @@ namespace SlackAPI
 
             if (!string.IsNullOrEmpty(thread_ts))
                 parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
 
             APIRequestWithToken(callback, parameters.ToArray());
         }

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -664,7 +664,9 @@ namespace SlackAPI
             string icon_url = null,
             string icon_emoji = null,
             bool? as_user = null,
-            string thread_ts = null)
+            string thread_ts = null,
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
 
@@ -709,6 +711,9 @@ namespace SlackAPI
             if (!string.IsNullOrEmpty(thread_ts))
                 parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
 
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
+
             return APIRequestWithTokenAsync<PostMessageResponse>(parameters.ToArray());
         }
 
@@ -720,7 +725,9 @@ namespace SlackAPI
             bool linkNames = false,
             Attachment[] attachments = null,
             bool as_user = false,
-            string thread_ts = null)
+            string thread_ts = null,
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string,string>> parameters = new List<Tuple<string,string>>();
 
@@ -744,6 +751,12 @@ namespace SlackAPI
 
             parameters.Add(new Tuple<string, string>("as_user", as_user.ToString()));
 
+            if (!string.IsNullOrEmpty(thread_ts))
+                parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+            
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
+
             return APIRequestWithTokenAsync<PostEphemeralResponse>(parameters.ToArray());
         }
 
@@ -761,7 +774,9 @@ namespace SlackAPI
             string icon_url = null,
             string icon_emoji = null,
             bool as_user = false,
-            string thread_ts = null)
+            string thread_ts = null,
+            bool? reply_broadcast = null
+            )
         {
             List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
 
@@ -806,6 +821,9 @@ namespace SlackAPI
 
             if (!string.IsNullOrEmpty(thread_ts))
                 parameters.Add(new Tuple<string, string>("thread_ts", thread_ts));
+
+            if (!string.IsNullOrEmpty(thread_ts) && reply_broadcast.HasValue)
+                parameters.Add(new Tuple<string, string>("reply_broadcast", reply_broadcast.ToString()));
 
             return APIRequestWithTokenAsync<ScheduleMessageResponse>(parameters.ToArray());
         }


### PR DESCRIPTION
This PR adds `reply_broadcast` to `PostMessage`, `PostEphemeralMessage` and `ScheduleMessage`. It also adds `thread_ts` to allow for threading on Ephemeral messages, which seems to have been started but never finished.

`reply_broadcast` will post to the parent channel/message, similar to the functionality of the "also send to channel" tickbox.
![CleanShot 2023-01-09 at 15 18 27@2x](https://user-images.githubusercontent.com/68839108/211245060-ce38857c-a08e-44ab-adba-378e8eb833b1.png)
