### PR TITLE
Added method to pin messages to channels

### DIFF
--- a/SlackAPI/PinAddedResponse.cs
+++ b/SlackAPI/PinAddedResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SlackAPI
+{
+    [RequestPath("pins.add")]
+    public class PinAddedResponse : Response
+    {
+    }
+}

--- a/SlackAPI/SlackClient.cs
+++ b/SlackAPI/SlackClient.cs
@@ -878,6 +878,22 @@ namespace SlackAPI
 
             APIRequestWithToken(callback, parameters.ToArray());
         }
+        
+        public void AddPin(
+            Action<PinAddedResponse> callback,
+            string channel = null,
+            string timestamp = null)
+        {
+            List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
+            
+            if (!string.IsNullOrEmpty(channel))
+                parameters.Add(new Tuple<string, string>("channel", channel));
+
+            if (!string.IsNullOrEmpty(timestamp))
+                parameters.Add(new Tuple<string, string>("timestamp", timestamp));
+
+            APIRequestWithToken(callback, parameters.ToArray());
+        }
 
         public void UploadFile(Action<FileUploadResponse> callback, byte[] fileData, string fileName, string[] channelIds, string title = null, string initialComment = null, bool useAsync = false, string fileType = null)
         {

--- a/SlackAPI/SlackTaskClient.cs
+++ b/SlackAPI/SlackTaskClient.cs
@@ -829,6 +829,21 @@ namespace SlackAPI
             return APIRequestWithTokenAsync<ReactionAddedResponse>(parameters.ToArray());
         }
 
+        public Task<PinAddedResponse> AddPinAsync(
+            string channel = null,
+            string timestamp = null)
+        {
+            List<Tuple<string, string>> parameters = new List<Tuple<string, string>>();
+            
+            if (!string.IsNullOrEmpty(channel))
+                parameters.Add(new Tuple<string, string>("channel", channel));
+
+            if (!string.IsNullOrEmpty(timestamp))
+                parameters.Add(new Tuple<string, string>("timestamp", timestamp));
+
+            return APIRequestWithTokenAsync<PinAddedResponse>(parameters.ToArray());
+        }
+
         public Task<DialogOpenResponse> DialogOpenAsync(
            string triggerId,
            Dialog dialog)


### PR DESCRIPTION
This PR adds `AddPin` to both clients. This allows the client to pin a message to a given channel based on its `ts` value.