### PR TITLE
Handle rate limiting

### DIFF
--- a/SlackAPI/Exceptions/RateLimitExceededException.cs
+++ b/SlackAPI/Exceptions/RateLimitExceededException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace SlackAPI.Exceptions
+{
+    public class RateLimitExceededException: Exception
+    {
+        public TimeSpan RetryIn { get; set; }
+        public RateLimitExceededException(TimeSpan retryIn) : base("Rate limit exceeded")
+        {
+            RetryIn = retryIn;
+        }
+    }
+}


### PR DESCRIPTION
Throw an exception that contains how long the caller should wait