### PR TITLE
Add json converters for the properties of Message that are defined as interfaces

### DIFF
--- a/SlackAPI/Block.cs
+++ b/SlackAPI/Block.cs
@@ -181,6 +181,12 @@
         public string initial_date { get; set; }
         public Confirm confirm { get; set; }
     }
+    
+    public class MarkdownElement : IElement
+    {
+        public string type { get; } = ElementTypes.Markdown;
+        public string text { get; set; }
+    }
 
     public class View
     {
@@ -227,10 +233,18 @@
         public const string ConversationSelect = "conversation_select";
         public const string Overflow = "overflow";
         public const string DatePicker = "datepicker";
+        public const string Markdown = "mrkdwn";
     }
 
-    public interface IElement { }
+    public interface IElement
+    {
+        string type { get; }
+    }
 
-    public interface IBlock { }
+    public interface IBlock
+    {
+        string type { get; }
+        string block_id { get; set; }
+    }
 
 }

--- a/SlackAPI/BlockConverter.cs
+++ b/SlackAPI/BlockConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SlackAPI
+{
+    public class BlockConverter: JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var block = JObject.Load(reader);
+            var blockTypeString = block["type"]?.Value<string>();
+            switch (blockTypeString)
+            {
+                case BlockTypes.Actions:
+                    return block.ToObject<ActionsBlock>(serializer);
+                case BlockTypes.Context:
+                    return block.ToObject<ContextBlock>(serializer);
+                case BlockTypes.Divider:
+                    return block.ToObject<DividerBlock>(serializer);
+                case BlockTypes.Header:
+                    return block.ToObject<HeaderBlock>(serializer);
+                case BlockTypes.Image:
+                    return block.ToObject<ImageBlock>(serializer);
+                case BlockTypes.Section:
+                    return block.ToObject<SectionBlock>(serializer);
+                default:
+                    return block.ToObject<Block>(serializer);
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IBlock);
+        }
+    }
+}

--- a/SlackAPI/ElementConverter.cs
+++ b/SlackAPI/ElementConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace SlackAPI
+{
+    public class ElementConverter: JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var element = JObject.Load(reader);
+            var elementTypeString = element["type"]?.Value<string>();
+            switch (elementTypeString)
+            {
+                case ElementTypes.Button:
+                    return element.ToObject<ButtonElement>(serializer);
+                case ElementTypes.ChannelSelect:
+                    return element.ToObject<ChannelSelectElement>(serializer);
+                case ElementTypes.ConversationSelect:
+                    return element.ToObject<ConversationSelectElement>(serializer);
+                case ElementTypes.DatePicker:
+                    return element.ToObject<DatePickerElement>(serializer);
+                case ElementTypes.ExternalSelect:
+                    return element.ToObject<ExternalSelectElement>(serializer);
+                case ElementTypes.Image:
+                    return element.ToObject<ImageElement>(serializer);
+                case ElementTypes.Markdown:
+                    return element.ToObject<MarkdownElement>(serializer);
+                case ElementTypes.Overflow:
+                    return element.ToObject<OverflowElement>(serializer);
+                case ElementTypes.UserSelect:
+                    return element.ToObject<UserSelectElement>(serializer);
+                case ElementTypes.StaticSelect:
+                    return element.ToObject<StaticSelectElement>(serializer);
+                default:
+                    return element.ToObject<Element>(serializer);
+            }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(IElement);
+        }
+    }
+}

--- a/SlackAPI/Extensions.cs
+++ b/SlackAPI/Extensions.cs
@@ -15,7 +15,7 @@ namespace SlackAPI
         };
 
         /// <summary>
-        /// Converts to a property JavaScript timestamp interpreted by Slack.  Also handles converting to UTC.
+        /// Converts to a proper JavaScript timestamp interpreted by Slack.  Also handles converting to UTC.
         /// </summary>
         /// <param name="that"></param>
         /// <returns></returns>

--- a/SlackAPI/Extensions.cs
+++ b/SlackAPI/Extensions.cs
@@ -7,10 +7,15 @@ namespace SlackAPI
 {
     public static class Extensions
     {
-        internal static readonly IList<JsonConverter> Converters = new List<JsonConverter> { new JavascriptDateTimeConverter() };
+        internal static readonly IList<JsonConverter> Converters = new List<JsonConverter>
+        {
+            new JavascriptDateTimeConverter(),
+            new BlockConverter(),
+            new ElementConverter()
+        };
 
         /// <summary>
-        /// Converts to a propert JavaScript timestamp interpretted by Slack.  Also handles converting to UTC.
+        /// Converts to a property JavaScript timestamp interpreted by Slack.  Also handles converting to UTC.
         /// </summary>
         /// <param name="that"></param>
         /// <returns></returns>


### PR DESCRIPTION
This allows messages with attachments to be deserialized solving the exception below:
```
Newtonsoft.Json.JsonSerializationException: Could not create an instance of type SlackAPI.IBlock. Type is an interface or abstract class and cannot be instantiated. Path 'messages[4].attachments[0].blocks[0].type', line 1, position 6150.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateNewObject(JsonReader reader, JsonObjectContract objectContract, JsonProperty containerMember, JsonProperty containerProperty, String id, Boolean& createdFromNonDefaultCreator)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateList(IList list, JsonReader reader, JsonArrayContract contract, JsonProperty containerProperty, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateList(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, Object existingValue, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonSerializer.Deserialize(JsonReader reader, Type objectType)
   at Newtonsoft.Json.JsonConvert.DeserializeObject(String value, Type type, JsonSerializerSettings settings)
   at Newtonsoft.Json.JsonConvert.DeserializeObject[T](String value, JsonSerializerSettings settings)
   at SlackAPI.Extensions.Deserialize[K](String data)
   at SlackAPI.RequestStateForTask`1.ExecuteResult()
   at SlackAPI.RequestStateForTask`1.ExecutePost()
```